### PR TITLE
feat(casl): implement RBAC with CASL policies and guards

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { PrismaModule } from './prisma/prisma.module.js';
 import { RedisModule, REDIS_CLIENT } from './redis/redis.module.js';
 import { HealthModule } from './modules/health/health.module.js';
 import { AuthModule } from './modules/auth/auth.module.js';
+import { CaslModule } from './modules/casl/casl.module.js';
 import { RedisThrottlerStorage } from './common/throttler-storage.js';
 
 @Module({
@@ -95,8 +96,11 @@ import { RedisThrottlerStorage } from './common/throttler-storage.js';
     // ── Health checks ──────────────────────────────────────
     HealthModule,
 
-    // ── Auth (JWT + refresh token + RBAC guard) ────────────
+    // ── Auth (JWT + refresh token) ─────────────────────────
     AuthModule,
+
+    // ── RBAC (CASL PoliciesGuard — runs after JwtAuthGuard) ─
+    CaslModule,
 
     // Feature modules will be added here in subsequent tasks:
     // AuthModule, UsersModule, ContentModule, SalesModule,

--- a/src/modules/casl/casl-ability.factory.spec.ts
+++ b/src/modules/casl/casl-ability.factory.spec.ts
@@ -1,0 +1,87 @@
+import { Role } from '../../generated/prisma/enums.js';
+import { CaslAbilityFactory, type AbilityUserContext } from './casl-ability.factory.js';
+
+describe('CaslAbilityFactory', () => {
+  const mockPrismaService = {
+    user: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  const mockRedis = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+  };
+
+  let factory: CaslAbilityFactory;
+
+  beforeEach(() => {
+    factory = new CaslAbilityFactory(mockPrismaService as never, mockRedis as never);
+    jest.clearAllMocks();
+    mockRedis.set.mockResolvedValue('OK');
+    mockRedis.del.mockResolvedValue(1);
+  });
+
+  it('builds from the authenticated user snapshot without re-querying Prisma', async () => {
+    mockRedis.get.mockResolvedValue(null);
+
+    const user: AbilityUserContext = {
+      id: 'user-1',
+      role: Role.SUPER_ADMIN,
+    };
+
+    const ability = await factory.createForUser(user);
+
+    expect(mockPrismaService.user.findUnique).not.toHaveBeenCalled();
+    expect(mockRedis.get).toHaveBeenCalledWith('casl:ability:user-1:SUPER_ADMIN');
+    expect(ability.can('manage', 'AuditLog')).toBe(true);
+  });
+
+  it('does not reuse a stale cache entry across role changes for the same user', async () => {
+    mockRedis.get.mockResolvedValue(null);
+
+    const adminAbility = await factory.createForUser({
+      id: 'user-1',
+      role: Role.SUPER_ADMIN,
+    });
+
+    const contentAbility = await factory.createForUser({
+      id: 'user-1',
+      role: Role.CONTENT_MANAGER,
+    });
+
+    expect(mockRedis.get).toHaveBeenNthCalledWith(1, 'casl:ability:user-1:SUPER_ADMIN');
+    expect(mockRedis.get).toHaveBeenNthCalledWith(2, 'casl:ability:user-1:CONTENT_MANAGER');
+    expect(adminAbility.can('manage', 'Company')).toBe(true);
+    expect(contentAbility.can('manage', 'Company')).toBe(false);
+  });
+
+  it('returns an empty ability for a soft-deleted user when loading from Prisma', async () => {
+    mockPrismaService.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      role: Role.SUPER_ADMIN,
+      isActive: true,
+      deletedAt: new Date(),
+    });
+
+    const ability = await factory.createForUser('user-1');
+
+    expect(mockPrismaService.user.findUnique).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      select: { id: true, role: true, isActive: true, deletedAt: true },
+    });
+    expect(ability.can('manage', 'all')).toBe(false);
+    expect(mockRedis.get).not.toHaveBeenCalled();
+  });
+
+  it('invalidates every role-specific cache key for a user', async () => {
+    await factory.invalidateCache('user-1');
+
+    expect(mockRedis.del).toHaveBeenCalledWith(
+      'casl:ability:user-1:SUPER_ADMIN',
+      'casl:ability:user-1:CONTENT_MANAGER',
+      'casl:ability:user-1:SALES_MANAGER',
+    );
+  });
+});

--- a/src/modules/casl/casl-ability.factory.ts
+++ b/src/modules/casl/casl-ability.factory.ts
@@ -1,0 +1,175 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { AbilityBuilder, createMongoAbility, MongoAbility, RawRuleOf } from '@casl/ability';
+import { Redis } from 'ioredis';
+import { PrismaService } from '../../prisma/prisma.service.js';
+import { REDIS_CLIENT } from '../../redis/redis.module.js';
+import { Role } from '../../generated/prisma/enums.js';
+
+/**
+ * The set of actions that can be performed in the system.
+ * 'manage' is a CASL wildcard meaning "any action".
+ */
+export type AppAction = 'manage' | 'create' | 'read' | 'update' | 'delete' | 'publish' | 'archive';
+
+/**
+ * The set of subjects (resource types) in the system.
+ * 'all' is a CASL wildcard meaning "any subject".
+ */
+export type AppSubjects =
+  | 'User'
+  | 'NewsArticle'
+  | 'Page'
+  | 'PageSection'
+  | 'Company'
+  | 'Purchase'
+  | 'AuditLog'
+  | 'all';
+
+/** Application-wide CASL ability type. */
+export type AppAbility = MongoAbility<[AppAction, AppSubjects]>;
+
+export interface AbilityUserContext {
+  id: string;
+  role: Role;
+  isActive?: boolean;
+  deletedAt?: Date | null;
+}
+
+/** Redis key TTL in seconds (5 minutes). */
+const ABILITY_CACHE_TTL_SECONDS = 300;
+
+/**
+ * Builds and caches CASL Abilities per user role.
+ *
+ * Cache strategy:
+ *   - Key:   casl:ability:<userId>:<role>
+ *   - Value: JSON-serialised RawRuleOf[] from ability.rules
+ *   - TTL:   300 s (5 min)
+ *   - HTTP request path: build from JwtStrategy's fresh DB-backed user snapshot,
+ *     so role changes take effect on the very next request.
+ *   - Non-HTTP path: string overload re-fetches the user from DB before building.
+ *   - Invalidation: call invalidateCache(userId) after any role, isActive, or
+ *     deletedAt mutation to evict older role-specific entries early.
+ *
+ * Role permission matrix:
+ *   SUPER_ADMIN    — manage all
+ *   CONTENT_MANAGER — manage NewsArticle | Page | PageSection;
+ *                     read  User | Company | AuditLog
+ *   SALES_MANAGER  — manage Company | Purchase;
+ *                     read  NewsArticle | Page | User
+ */
+@Injectable()
+export class CaslAbilityFactory {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+  ) {}
+
+  async createForUser(userId: string): Promise<AppAbility>;
+  async createForUser(user: AbilityUserContext): Promise<AppAbility>;
+
+  /**
+   * Returns a fully-built AppAbility for the given user context.
+   *
+   * Prefer passing the authenticated request user so the ability is derived
+   * from JwtStrategy's fresh DB-backed role instead of a stale cache entry.
+   * The string overload exists for non-request code paths that only have a userId.
+   */
+  async createForUser(userOrId: string | AbilityUserContext): Promise<AppAbility> {
+    const user = typeof userOrId === 'string' ? await this.loadUserContext(userOrId) : userOrId;
+
+    if (
+      !user ||
+      user.isActive === false ||
+      (user.deletedAt !== undefined && user.deletedAt !== null)
+    ) {
+      return createMongoAbility<AppAbility>([]);
+    }
+
+    const cacheKey = this.getCacheKey(user.id, user.role);
+
+    const cached = await this.redis.get(cacheKey);
+    if (cached) {
+      try {
+        // Re-hydrate from serialised rules — safe because we control what we cached.
+        const rules = JSON.parse(cached) as RawRuleOf<AppAbility>[];
+        return createMongoAbility<AppAbility>(rules);
+      } catch {
+        await this.redis.del(cacheKey).catch(() => {
+          // Corrupt cache entry is non-critical; rebuild below.
+        });
+      }
+    }
+
+    const ability = this.buildAbility(user.role);
+
+    // Cache serialised rules; ignore Redis errors non-fatally —
+    // a cache miss on the next request simply re-fetches from DB.
+    await this.redis
+      .set(cacheKey, JSON.stringify(ability.rules), 'EX', ABILITY_CACHE_TTL_SECONDS)
+      .catch(() => {
+        // Redis write failure is non-critical: ability was already built.
+      });
+
+    return ability;
+  }
+
+  /**
+   * Removes the cached ability for the given user.
+   * Must be called after changing a user's role, isActive, or deletedAt flag.
+   */
+  async invalidateCache(userId: string): Promise<void> {
+    await this.redis.del(...Object.values(Role).map((role) => this.getCacheKey(userId, role)));
+  }
+
+  // ─── Private ───────────────────────────────────────────────────────────────
+
+  private getCacheKey(userId: string, role: Role): string {
+    return `casl:ability:${userId}:${role}`;
+  }
+
+  private async loadUserContext(userId: string): Promise<AbilityUserContext | null> {
+    return this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, role: true, isActive: true, deletedAt: true },
+    });
+  }
+
+  private buildAbility(role: Role): AppAbility {
+    const { can, build } = new AbilityBuilder<AppAbility>(createMongoAbility);
+
+    switch (role) {
+      case Role.SUPER_ADMIN:
+        // Full unrestricted access to every resource and action.
+        can('manage', 'all');
+        break;
+
+      case Role.CONTENT_MANAGER:
+        // Full lifecycle control over content resources.
+        can('manage', 'NewsArticle');
+        can('manage', 'Page');
+        can('manage', 'PageSection');
+        // Read-only access to supporting resources.
+        can('read', 'User');
+        can('read', 'Company');
+        can('read', 'AuditLog');
+        break;
+
+      case Role.SALES_MANAGER:
+        // Full control over sales-related resources.
+        can('manage', 'Company');
+        can('manage', 'Purchase');
+        // Read content and user list (to associate with purchases).
+        can('read', 'NewsArticle');
+        can('read', 'Page');
+        can('read', 'User');
+        break;
+
+      default:
+        // Unknown role → no permissions (fail-safe).
+        break;
+    }
+
+    return build();
+  }
+}

--- a/src/modules/casl/casl.module.ts
+++ b/src/modules/casl/casl.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { CaslAbilityFactory } from './casl-ability.factory.js';
+import { PoliciesGuard } from './guards/policies.guard.js';
+
+/**
+ * CaslModule wires RBAC infrastructure:
+ *   - CaslAbilityFactory — builds and caches per-user AppAbility instances.
+ *   - PoliciesGuard      — registered as a global APP_GUARD so it runs on
+ *                          every route after JwtAuthGuard.
+ *
+ * Import CaslModule in AppModule AFTER AuthModule so the guard execution
+ * order is: ThrottlerGuard → JwtAuthGuard → PoliciesGuard.
+ *
+ * CaslAbilityFactory is exported so other modules can call
+ * invalidateCache(userId) whenever a user's role or active state changes.
+ */
+@Module({
+  providers: [
+    CaslAbilityFactory,
+    {
+      provide: APP_GUARD,
+      useClass: PoliciesGuard,
+    },
+  ],
+  exports: [CaslAbilityFactory],
+})
+export class CaslModule {}

--- a/src/modules/casl/decorators/check-policies.decorator.ts
+++ b/src/modules/casl/decorators/check-policies.decorator.ts
@@ -1,0 +1,34 @@
+import { SetMetadata } from '@nestjs/common';
+import type { PolicyHandler } from '../interfaces/policy-handler.interface.js';
+
+/**
+ * Metadata key used to store policy handlers on route handlers/controllers.
+ * Used by PoliciesGuard to retrieve and evaluate the handlers.
+ */
+export const CHECK_POLICIES_KEY = 'check_policies';
+
+/**
+ * Attaches one or more policy handlers to a route or controller.
+ * The PoliciesGuard evaluates each handler against the current user's AppAbility.
+ * All handlers must return true for the request to be allowed.
+ *
+ * @example — callback form
+ * @CheckPolicies((ability) => ability.can('read', 'NewsArticle'))
+ * @Get()
+ * findAll() {}
+ *
+ * @example — class form
+ * @CheckPolicies(ReadNewsArticleHandler)
+ * @Get(':id')
+ * findOne() {}
+ *
+ * @example — multiple policies (all must pass)
+ * @CheckPolicies(
+ *   (a) => a.can('read', 'NewsArticle'),
+ *   (a) => a.can('read', 'AuditLog'),
+ * )
+ * @Get('with-audit')
+ * findWithAudit() {}
+ */
+export const CheckPolicies = (...handlers: PolicyHandler[]) =>
+  SetMetadata(CHECK_POLICIES_KEY, handlers);

--- a/src/modules/casl/guards/policies.guard.spec.ts
+++ b/src/modules/casl/guards/policies.guard.spec.ts
@@ -13,6 +13,12 @@ class ReadCompanyHandler implements IPolicyHandler {
   }
 }
 
+class ThrowingHandler implements IPolicyHandler {
+  handle(): boolean {
+    throw new Error('policy handler bug');
+  }
+}
+
 describe('PoliciesGuard', () => {
   const mockReflector = {
     getAllAndOverride: jest.fn(),
@@ -137,5 +143,24 @@ describe('PoliciesGuard', () => {
 
     await expect(guard.canActivate(createExecutionContext(user))).resolves.toBe(true);
     expect(mockModuleRef.resolve).toHaveBeenCalled();
+  });
+
+  it('propagates handler execution errors instead of masking them with a fallback resolve', async () => {
+    const user: AuthenticatedUser = {
+      id: 'user-1',
+      email: 'user@example.com',
+      role: Role.CONTENT_MANAGER,
+    };
+
+    mockReflector.getAllAndOverride.mockReturnValue([ThrowingHandler]);
+    mockCaslAbilityFactory.createForUser.mockResolvedValue({
+      can: jest.fn().mockReturnValue(true),
+    });
+    mockModuleRef.get.mockReturnValue(new ThrowingHandler());
+
+    await expect(guard.canActivate(createExecutionContext(user))).rejects.toThrow(
+      'policy handler bug',
+    );
+    expect(mockModuleRef.resolve).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/casl/guards/policies.guard.spec.ts
+++ b/src/modules/casl/guards/policies.guard.spec.ts
@@ -1,0 +1,141 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector, ModuleRef } from '@nestjs/core';
+import type { ExecutionContext } from '@nestjs/common';
+import { Role } from '../../../generated/prisma/enums.js';
+import type { AuthenticatedUser } from '../../auth/decorators/current-user.decorator.js';
+import type { AppAbility, IPolicyHandler } from '../index.js';
+import { CaslAbilityFactory } from '../casl-ability.factory.js';
+import { PoliciesGuard } from './policies.guard.js';
+
+class ReadCompanyHandler implements IPolicyHandler {
+  handle(ability: AppAbility): boolean {
+    return ability.can('read', 'Company');
+  }
+}
+
+describe('PoliciesGuard', () => {
+  const mockReflector = {
+    getAllAndOverride: jest.fn(),
+  };
+
+  const mockCaslAbilityFactory = {
+    createForUser: jest.fn(),
+  };
+
+  const mockModuleRef = {
+    get: jest.fn(),
+    resolve: jest.fn(),
+  };
+
+  let guard: PoliciesGuard;
+
+  beforeEach(() => {
+    guard = new PoliciesGuard(
+      mockReflector as never as Reflector,
+      mockCaslAbilityFactory as never as CaslAbilityFactory,
+      mockModuleRef as never as ModuleRef,
+    );
+    jest.clearAllMocks();
+  });
+
+  function createExecutionContext(user?: AuthenticatedUser): ExecutionContext {
+    return {
+      getHandler: () => createExecutionContext,
+      getClass: () => PoliciesGuard,
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
+    } as never as ExecutionContext;
+  }
+
+  it('passes through when no policies are attached', async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(undefined);
+
+    await expect(guard.canActivate(createExecutionContext())).resolves.toBe(true);
+    expect(mockCaslAbilityFactory.createForUser).not.toHaveBeenCalled();
+  });
+
+  it('throws when policy-protected routes have no authenticated user', async () => {
+    mockReflector.getAllAndOverride.mockReturnValue([
+      (ability: AppAbility) => ability.can('read', 'Company'),
+    ]);
+
+    await expect(guard.canActivate(createExecutionContext())).rejects.toThrow(ForbiddenException);
+  });
+
+  it('evaluates callback policies against the authenticated request user', async () => {
+    const user: AuthenticatedUser = {
+      id: 'user-1',
+      email: 'user@example.com',
+      role: Role.SALES_MANAGER,
+    };
+
+    mockReflector.getAllAndOverride.mockReturnValue([
+      (ability: AppAbility) => ability.can('manage', 'Company'),
+    ]);
+    mockCaslAbilityFactory.createForUser.mockResolvedValue({
+      can: jest.fn().mockReturnValue(true),
+    });
+
+    await expect(guard.canActivate(createExecutionContext(user))).resolves.toBe(true);
+    expect(mockCaslAbilityFactory.createForUser).toHaveBeenCalledWith(user);
+  });
+
+  it('resolves class-token handlers through ModuleRef', async () => {
+    const user: AuthenticatedUser = {
+      id: 'user-1',
+      email: 'user@example.com',
+      role: Role.CONTENT_MANAGER,
+    };
+
+    mockReflector.getAllAndOverride.mockReturnValue([ReadCompanyHandler]);
+    mockCaslAbilityFactory.createForUser.mockResolvedValue({
+      can: jest.fn().mockImplementation((action: string, subject: string) => {
+        return action === 'read' && subject === 'Company';
+      }),
+    });
+    mockModuleRef.get.mockReturnValue(new ReadCompanyHandler());
+
+    await expect(guard.canActivate(createExecutionContext(user))).resolves.toBe(true);
+    expect(mockModuleRef.get).toHaveBeenCalledWith(ReadCompanyHandler, { strict: false });
+  });
+
+  it('supports async callback policies', async () => {
+    const user: AuthenticatedUser = {
+      id: 'user-1',
+      email: 'user@example.com',
+      role: Role.CONTENT_MANAGER,
+    };
+
+    mockReflector.getAllAndOverride.mockReturnValue([
+      async (ability: AppAbility) => ability.can('read', 'AuditLog'),
+    ]);
+    mockCaslAbilityFactory.createForUser.mockResolvedValue({
+      can: jest.fn().mockReturnValue(false),
+    });
+
+    await expect(guard.canActivate(createExecutionContext(user))).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('falls back to ModuleRef.resolve when ModuleRef.get cannot resolve the handler', async () => {
+    const user: AuthenticatedUser = {
+      id: 'user-1',
+      email: 'user@example.com',
+      role: Role.CONTENT_MANAGER,
+    };
+
+    mockReflector.getAllAndOverride.mockReturnValue([ReadCompanyHandler]);
+    mockCaslAbilityFactory.createForUser.mockResolvedValue({
+      can: jest.fn().mockReturnValue(true),
+    });
+    mockModuleRef.get.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    mockModuleRef.resolve.mockResolvedValue(new ReadCompanyHandler());
+
+    await expect(guard.canActivate(createExecutionContext(user))).resolves.toBe(true);
+    expect(mockModuleRef.resolve).toHaveBeenCalled();
+  });
+});

--- a/src/modules/casl/guards/policies.guard.ts
+++ b/src/modules/casl/guards/policies.guard.ts
@@ -88,24 +88,27 @@ export class PoliciesGuard implements CanActivate {
   ): Promise<boolean> {
     if (typeof handler === 'function') {
       if (this.isPolicyHandlerType(handler)) {
-        const contextId = ContextIdFactory.getByRequest(request);
-        try {
-          const instance = this.moduleRef.get<IPolicyHandler>(handler as PolicyHandlerType, {
-            strict: false,
-          });
-          return instance.handle(ability);
-        } catch {
-          const resolved = await this.moduleRef.resolve<IPolicyHandler>(
-            handler as PolicyHandlerType,
-            contextId,
-          );
-          return resolved.handle(ability);
-        }
+        const instance = await this.resolvePolicyHandler(handler as PolicyHandlerType, request);
+        return instance.handle(ability);
       }
 
       return (handler as PolicyHandlerCallback)(ability);
     }
     return (handler as IPolicyHandler).handle(ability);
+  }
+
+  private async resolvePolicyHandler(
+    handlerType: PolicyHandlerType,
+    request: Request,
+  ): Promise<IPolicyHandler> {
+    try {
+      return this.moduleRef.get<IPolicyHandler>(handlerType, {
+        strict: false,
+      });
+    } catch {
+      const contextId = ContextIdFactory.getByRequest(request);
+      return this.moduleRef.resolve<IPolicyHandler>(handlerType, contextId);
+    }
   }
 
   private isPolicyHandlerType(handler: PolicyHandler): handler is PolicyHandlerType {

--- a/src/modules/casl/guards/policies.guard.ts
+++ b/src/modules/casl/guards/policies.guard.ts
@@ -1,0 +1,114 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { ContextIdFactory, ModuleRef, Reflector } from '@nestjs/core';
+import type { Request } from 'express';
+import { CaslAbilityFactory, type AppAbility } from '../casl-ability.factory.js';
+import { CHECK_POLICIES_KEY } from '../decorators/check-policies.decorator.js';
+import type {
+  IPolicyHandler,
+  PolicyHandler,
+  PolicyHandlerCallback,
+  PolicyHandlerType,
+} from '../interfaces/policy-handler.interface.js';
+import type { AuthenticatedUser } from '../../auth/decorators/current-user.decorator.js';
+
+/**
+ * Global RBAC guard — evaluates @CheckPolicies() handlers against the current
+ * user's CASL AppAbility.
+ *
+ * Execution order:
+ *   ThrottlerGuard → JwtAuthGuard → PoliciesGuard
+ *
+ * Behaviour:
+ *   - Routes without @CheckPolicies() pass through (JWT guard already enforces auth).
+ *   - Routes with @CheckPolicies() must have ALL handlers return true.
+ *   - Throws 403 Forbidden (not 401) on policy failure to distinguish RBAC
+ *     failures from authentication failures.
+ *
+ * Registered as APP_GUARD in CaslModule so it applies to every route.
+ */
+@Injectable()
+export class PoliciesGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly caslAbilityFactory: CaslAbilityFactory,
+    private readonly moduleRef: ModuleRef,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const handlers = this.reflector.getAllAndOverride<PolicyHandler[] | undefined>(
+      CHECK_POLICIES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    // No policy constraints on this route — let it through. Authentication
+    // has already been confirmed by JwtAuthGuard running earlier.
+    if (!handlers || handlers.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request & { user?: AuthenticatedUser }>();
+
+    const user = request.user;
+
+    // A route with @CheckPolicies() on a @Public() route is a misconfiguration.
+    // Deny access — there is no authenticated user to evaluate policies against.
+    if (!user) {
+      throw new ForbiddenException('Insufficient permissions');
+    }
+
+    const ability = await this.caslAbilityFactory.createForUser(user);
+
+    const allPass = await this.evalHandlers(handlers, ability, request);
+
+    if (!allPass) {
+      throw new ForbiddenException('Insufficient permissions');
+    }
+
+    return true;
+  }
+
+  private async evalHandlers(
+    handlers: PolicyHandler[],
+    ability: AppAbility,
+    request: Request,
+  ): Promise<boolean> {
+    for (const handler of handlers) {
+      if (!(await this.execHandler(handler, ability, request))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private async execHandler(
+    handler: PolicyHandler,
+    ability: AppAbility,
+    request: Request,
+  ): Promise<boolean> {
+    if (typeof handler === 'function') {
+      if (this.isPolicyHandlerType(handler)) {
+        const contextId = ContextIdFactory.getByRequest(request);
+        try {
+          const instance = this.moduleRef.get<IPolicyHandler>(handler as PolicyHandlerType, {
+            strict: false,
+          });
+          return instance.handle(ability);
+        } catch {
+          const resolved = await this.moduleRef.resolve<IPolicyHandler>(
+            handler as PolicyHandlerType,
+            contextId,
+          );
+          return resolved.handle(ability);
+        }
+      }
+
+      return (handler as PolicyHandlerCallback)(ability);
+    }
+    return (handler as IPolicyHandler).handle(ability);
+  }
+
+  private isPolicyHandlerType(handler: PolicyHandler): handler is PolicyHandlerType {
+    return typeof handler === 'function' && 'prototype' in handler && 'handle' in handler.prototype;
+  }
+}

--- a/src/modules/casl/index.ts
+++ b/src/modules/casl/index.ts
@@ -1,0 +1,10 @@
+export { CaslModule } from './casl.module.js';
+export { CaslAbilityFactory } from './casl-ability.factory.js';
+export type { AppAbility, AppAction, AppSubjects } from './casl-ability.factory.js';
+export { CheckPolicies, CHECK_POLICIES_KEY } from './decorators/check-policies.decorator.js';
+export type {
+  PolicyHandler,
+  IPolicyHandler,
+  PolicyHandlerCallback,
+  PolicyHandlerType,
+} from './interfaces/policy-handler.interface.js';

--- a/src/modules/casl/interfaces/policy-handler.interface.ts
+++ b/src/modules/casl/interfaces/policy-handler.interface.ts
@@ -1,0 +1,39 @@
+import type { Type } from '@nestjs/common';
+import type { AppAbility } from '../casl-ability.factory.js';
+
+/**
+ * Object-style policy handler — useful when you want to encapsulate complex
+ * permission logic in an injectable class that can have its own dependencies.
+ *
+ * @example
+ * @Injectable()
+ * class ReadNewsArticleHandler implements IPolicyHandler {
+ *   handle(ability: AppAbility): boolean {
+ *     return ability.can('read', 'NewsArticle');
+ *   }
+ * }
+ */
+export interface IPolicyHandler {
+  handle(ability: AppAbility): boolean | Promise<boolean>;
+}
+
+/**
+ * Inline callback-style policy handler — suitable for simple, one-off checks
+ * directly on route decorators.
+ *
+ * @example
+ * @CheckPolicies((ability) => ability.can('read', 'NewsArticle'))
+ */
+export type PolicyHandlerCallback = (ability: AppAbility) => boolean | Promise<boolean>;
+
+/**
+ * Class-token policy handler — resolved through Nest's container so the
+ * handler can depend on other providers.
+ */
+export type PolicyHandlerType = Type<IPolicyHandler>;
+
+/**
+ * A policy handler can be an existing object instance, a callback, or a Nest
+ * provider class token resolved by PoliciesGuard through ModuleRef.
+ */
+export type PolicyHandler = IPolicyHandler | PolicyHandlerCallback | PolicyHandlerType;


### PR DESCRIPTION
## Pull request overview

This PR introduces a CASL-based RBAC infrastructure layer for the NestJS backend, adding a global `PoliciesGuard` that enforces route-level permissions via `@CheckPolicies()` decorators and a cached `CaslAbilityFactory` for building user abilities.

**Changes:**
- Added CASL policy handler abstractions (`IPolicyHandler`, callbacks, and class-token handlers) plus a `@CheckPolicies()` decorator for attaching policy checks to routes.
- Implemented a global `PoliciesGuard` (registered via `APP_GUARD`) that evaluates attached policies against the current user’s CASL ability.
- Added `CaslAbilityFactory` with Redis caching and invalidation, plus unit tests for both the factory and guard.

### Reviewed changes

Copilot reviewed 9 out of 9 changed files in this pull request and generated 1 comment.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/modules/casl/interfaces/policy-handler.interface.ts | Defines supported policy handler shapes (object, callback, class token). |
| src/modules/casl/index.ts | Public barrel exports for the CASL module, decorators, and types. |
| src/modules/casl/guards/policies.guard.ts | Global guard that loads abilities and evaluates `@CheckPolicies()` handlers. |
| src/modules/casl/guards/policies.guard.spec.ts | Unit coverage for policy evaluation behavior and handler resolution paths. |
| src/modules/casl/decorators/check-policies.decorator.ts | Adds the decorator + metadata key used by `PoliciesGuard`. |
| src/modules/casl/casl.module.ts | Registers `PoliciesGuard` as an `APP_GUARD` and exports `CaslAbilityFactory`. |
| src/modules/casl/casl-ability.factory.ts | Builds role-based abilities, caches rules in Redis, and supports invalidation. |
| src/modules/casl/casl-ability.factory.spec.ts | Unit tests for ability building, caching behavior, and invalidation. |
| src/app.module.ts | Wires `CaslModule` into the application module imports. |
</details>






---

💡 <a href="/KiraProsto/ICGroup-backend/new/main?filename=.github/instructions/*.instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Learn how to get started</a>.