### PR TITLE
feat: add card data schemas for various content types and validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,10 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.13.1",
+        "prisma": "^7.5.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "sanitize-html": "^2.17.1",
         "uuid": "^13.0.0",
         "zod": "^3.25.76"
       },
@@ -64,6 +66,7 @@
         "@types/node": "^22.19.13",
         "@types/passport-jwt": "^4.0.1",
         "@types/pg": "^8.11.10",
+        "@types/sanitize-html": "^2.16.1",
         "@types/supertest": "^7.2.0",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.19.1",
@@ -75,7 +78,6 @@
         "jest": "^30.2.0",
         "lint-staged": "^16.3.1",
         "prettier": "^3.4.2",
-        "prisma": "^7.5.0",
         "supertest": "^7.0.0",
         "ts-jest": "^29.4.6",
         "tsx": "^4.21.0",
@@ -744,7 +746,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
       "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@chevrotain/gast": "10.5.0",
@@ -756,14 +757,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@chevrotain/gast": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
       "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@chevrotain/types": "10.5.0",
@@ -774,21 +773,18 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@chevrotain/types": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
       "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
       "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@colors/colors": {
@@ -1130,14 +1126,12 @@
       "version": "0.3.15",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
       "integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "pglite-server": "dist/scripts/server.js"
@@ -1150,7 +1144,6 @@
       "version": "0.2.20",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
       "integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.3.15"
@@ -1823,7 +1816,6 @@
       "version": "1.19.9",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
       "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2951,7 +2943,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
       "integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chevrotain": "^10.5.0",
@@ -3932,7 +3923,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.5.0.tgz",
       "integrity": "sha512-1J/9YEX7A889xM46PYg9e8VAuSL1IUmXJW3tEhMv7XQHDWlfC9YSkIw9sTYRaq5GswGlxZ+GnnyiNsUZ9JJhSQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -3951,7 +3941,6 @@
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
       "integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@electric-sql/pglite": "0.3.15",
@@ -3986,7 +3975,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.5.0.tgz",
       "integrity": "sha512-ondGRhzoaVpRWvFaQ5wH5zS1BIbhzbKqczKjCn6j3L0Zfe/LInjcEg8+xtB49AuZBX30qyx1ZtGoootUohz2pw==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4000,21 +3988,18 @@
       "version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e.tgz",
       "integrity": "sha512-E+iRV/vbJLl8iGjVr6g/TEWokA+gjkV/doZkaQN1i/ULVdDwGnPJDfLUIFGS3BVwlG/m6L8T4x1x5isl8hGMxA==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/debug": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.5.0.tgz",
       "integrity": "sha512-163+nffny0JoPEkDhfNco0vcuT3ymIJc9+WX7MHSQhfkeKUmKe9/wqvGk5SjppT93DtBjVwr5HPJYlXbzm6qtg==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
       "integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.5.0"
@@ -4024,7 +4009,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.5.0.tgz",
       "integrity": "sha512-kZCl2FV54qnyrVdnII8MI6qvt7HfU6Cbiz8dZ8PXz4f4lbSw45jEB9/gEMK2SGdiNhBKyk/Wv95uthoLhGMLYA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.5.0",
@@ -4036,14 +4020,12 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.5.0.tgz",
       "integrity": "sha512-163+nffny0JoPEkDhfNco0vcuT3ymIJc9+WX7MHSQhfkeKUmKe9/wqvGk5SjppT93DtBjVwr5HPJYlXbzm6qtg==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
       "integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.5.0"
@@ -4053,7 +4035,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
       "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.2.0"
@@ -4063,21 +4044,18 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
       "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/query-plan-executor": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
       "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/studio-core": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.21.1.tgz",
       "integrity": "sha512-bOGqG/eMQtKC0XVvcVLRmhWWzm/I+0QUWqAEhEBtetpuS3k3V4IWqKGUONkAIT223DNXJMxMtZp36b1FmcdPeg==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19 || ^22.12 || ^24.0",
@@ -5275,11 +5253,40 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/@types/send": {
@@ -6809,7 +6816,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
       "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
@@ -7382,7 +7388,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
       "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -7411,7 +7416,6 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -7567,7 +7571,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
       "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@chevrotain/cst-dts-gen": "10.5.0",
@@ -7582,14 +7585,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -7631,7 +7632,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -7968,7 +7968,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/consola": {
@@ -8200,7 +8199,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true
     },
@@ -8289,7 +8287,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8299,7 +8296,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -8332,7 +8328,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -8367,7 +8362,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -8399,6 +8393,73 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dot-prop": {
@@ -8493,7 +8554,6 @@
       "version": "3.18.4",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
       "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -8530,7 +8590,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -8564,7 +8623,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -9195,7 +9253,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/ext-list": {
@@ -9229,7 +9286,6 @@
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -9252,7 +9308,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -9510,7 +9565,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -9718,7 +9772,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
@@ -9795,7 +9848,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
       "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/get-proto": {
@@ -9841,7 +9893,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -10022,21 +10073,18 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/grammex": {
       "version": "3.1.12",
       "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
       "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/graphmatch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
       "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/handlebars": {
@@ -10151,7 +10199,6 @@
       "version": "4.11.4",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -10163,6 +10210,37 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
@@ -10195,7 +10273,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
       "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/http2-wrapper": {
@@ -10502,6 +10579,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -10512,7 +10598,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -11306,7 +11391,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -11520,7 +11604,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -12067,7 +12150,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/lowercase-keys": {
@@ -12097,7 +12179,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
       "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
@@ -12529,7 +12610,6 @@
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
       "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.1",
@@ -12550,13 +12630,30 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
       "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "lru.min": "^1.1.0"
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/napi-postinstall": {
@@ -12627,7 +12724,6 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/node-gyp-build": {
@@ -12710,7 +12806,6 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
       "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.2.0",
@@ -12728,7 +12823,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
       "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -12756,7 +12850,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -12935,6 +13028,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -13060,7 +13159,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pause": {
@@ -13079,7 +13177,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -13184,7 +13281,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -13293,7 +13389,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
       "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.2",
@@ -13311,11 +13406,38 @@
         "node": ">=4"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/postgres": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
       "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
-      "devOptional": true,
       "license": "Unlicense",
       "engines": {
         "node": ">=12"
@@ -13435,7 +13557,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.5.0.tgz",
       "integrity": "sha512-n30qZpWehaYQzigLjmuPisyEsvOzHt7bZeRyg8gZ5DvJo9FGjD+gNaY59Ns3hlLD5/jZH5GBeftIss0jDbUoLg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13469,7 +13590,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -13481,7 +13601,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/prosemirror-changeset": {
@@ -13794,7 +13913,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -13805,7 +13923,6 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -13816,7 +13933,6 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13851,7 +13967,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -13892,14 +14007,12 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
       "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/remeda": {
       "version": "2.33.4",
       "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
       "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/remeda"
@@ -14016,7 +14129,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -14086,11 +14198,24 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sanitize-html": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.1.tgz",
+      "integrity": "sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true
     },
@@ -14241,8 +14366,7 @@
     "node_modules/seq-queue": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-      "devOptional": true
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
@@ -14376,7 +14500,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -14477,6 +14600,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -14518,7 +14650,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
       "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -14566,7 +14697,6 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/streamsearch": {
@@ -15091,7 +15221,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
       "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15592,7 +15721,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
       "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"
@@ -16073,7 +16201,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
       "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "grammex": "^3.1.11",

--- a/package.json
+++ b/package.json
@@ -65,10 +65,11 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.13.1",
+    "prisma": "^7.5.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "sanitize-html": "^2.17.1",
     "uuid": "^13.0.0",
-    "prisma": "^7.5.0",
     "zod": "^3.25.76"
   },
   "lint-staged": {
@@ -132,6 +133,7 @@
     "@types/node": "^22.19.13",
     "@types/passport-jwt": "^4.0.1",
     "@types/pg": "^8.11.10",
+    "@types/sanitize-html": "^2.16.1",
     "@types/supertest": "^7.2.0",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.19.1",

--- a/prisma/migrations/20260313120001_add_article_cards/migration.sql
+++ b/prisma/migrations/20260313120001_add_article_cards/migration.sql
@@ -1,0 +1,35 @@
+-- Migration: add article_cards table and make news_articles.body nullable
+--
+-- Changes:
+--   1. Add ArticleCardType PostgreSQL enum
+--   2. Make news_articles.body column nullable (new drafts have no body yet)
+--   3. Create article_cards table with FK → news_articles (CASCADE DELETE)
+--   4. Add composite index (article_id, order) for ordered card fetching
+
+-- 1. ArticleCardType enum
+CREATE TYPE "ArticleCardType" AS ENUM ('TEXT', 'QUOTE', 'PUBLICATION', 'IMAGE', 'VIDEO');
+
+-- 2. Make body nullable — existing rows keep their JSON value
+ALTER TABLE "news_articles" ALTER COLUMN "body" DROP NOT NULL;
+
+-- 3. article_cards table
+CREATE TABLE "article_cards" (
+    "id"          TEXT             NOT NULL,
+    "article_id"  TEXT             NOT NULL,
+    "type"        "ArticleCardType" NOT NULL,
+    "order"       INTEGER          NOT NULL,
+    "data"        JSONB            NOT NULL,
+    "created_at"  TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"  TIMESTAMPTZ      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "article_cards_pkey" PRIMARY KEY ("id")
+);
+
+-- 4. FK: cascade deletes article cards when the parent article is hard-deleted.
+--    Soft-deletes on NewsArticle do NOT cascade — cards remain until hard delete.
+ALTER TABLE "article_cards"
+    ADD CONSTRAINT "article_cards_article_id_fkey"
+    FOREIGN KEY ("article_id") REFERENCES "news_articles"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 5. Unique composite index for ordered card listing and position integrity
+CREATE UNIQUE INDEX "article_cards_article_id_order_key" ON "article_cards"("article_id", "order");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,14 @@ enum ArticleType {
   ANNOUNCEMENT
 }
 
+enum ArticleCardType {
+  TEXT // Rich-text block (Tiptap ProseMirror JSON)
+  QUOTE // Pull-quote / blockquote
+  PUBLICATION // Embedded reference to another NewsArticle
+  IMAGE // Single image with optional caption
+  VIDEO // Video embed (URL + optional caption)
+}
+
 enum AuditAction {
   CREATE
   UPDATE
@@ -175,8 +183,8 @@ model NewsArticle {
   excerptTitle     String?                  @map("excerpt_title")
   excerpt          String? // plain text body of the anons block
   excerptImage     String?                  @map("excerpt_image")
-  // Rich-text body — Source of truth (ProseMirror/Tiptap JSON)
-  body             Json
+  // Rich-text body — compiled from cards on publish (ProseMirror/Tiptap JSON + cards array)
+  body             Json?
   // Pre-rendered HTML (generated on publish via generateHTML())
   bodyHtml         String?                  @map("body_html")
   // Plain text extraction (generated on publish, powers FTS)
@@ -207,8 +215,9 @@ model NewsArticle {
   updatedAt        DateTime                 @updatedAt @map("updated_at")
   deletedAt        DateTime?                @map("deleted_at")
 
-  author User    @relation(fields: [authorId], references: [id])
-  rubric Rubric? @relation(fields: [rubricId], references: [id], onDelete: SetNull)
+  author User          @relation(fields: [authorId], references: [id])
+  rubric Rubric?       @relation(fields: [rubricId], references: [id], onDelete: SetNull)
+  cards  ArticleCard[]
 
   @@index([status, publishedAt])
   @@index([authorId])
@@ -216,6 +225,36 @@ model NewsArticle {
   @@index([status, articleType, publicationIndex])
   @@index([status, rubricId, publicationIndex])
   @@map("news_articles")
+}
+
+// ─────────────────────────────────────────────
+//  CONTENT — ARTICLE CARDS
+// ─────────────────────────────────────────────
+
+/**
+ * Article content is built from ordered cards. Each card has a type and a
+ * JSONB data payload validated by Zod in the application layer.
+ * Card.data shapes (per ArticleCardType):
+ * TEXT        → { body: JSONContent }            — Tiptap ProseMirror document
+ * QUOTE       → { text: string }                 — plain blockquote text
+ * PUBLICATION → { articleId: string }            — id of the referenced NewsArticle
+ * IMAGE       → { url: string; caption?: string }— http/https URL only
+ * VIDEO       → { url: string; caption?: string }— http/https URL only
+ */
+model ArticleCard {
+  id        String          @id @default(uuid())
+  articleId String          @map("article_id")
+  type      ArticleCardType
+  order     Int
+  data      Json
+  createdAt DateTime        @default(now()) @map("created_at")
+  updatedAt DateTime        @updatedAt @map("updated_at")
+
+  article NewsArticle @relation(fields: [articleId], references: [id], onDelete: Cascade)
+
+  // Keeps card positions unique per article and covers ordered card fetches.
+  @@unique([articleId, order])
+  @@map("article_cards")
 }
 
 // Full-text search column (applied via raw SQL — see 20260309000002_add_news_fts):

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -183,7 +183,7 @@ model NewsArticle {
   excerptTitle     String?                  @map("excerpt_title")
   excerpt          String? // plain text body of the anons block
   excerptImage     String?                  @map("excerpt_image")
-  // Rich-text body — compiled from cards on publish (ProseMirror/Tiptap JSON + cards array)
+  // Rich-text body — compiled Tiptap/ProseMirror JSON document (cards stored separately in article_cards)
   body             Json?
   // Pre-rendered HTML (generated on publish via generateHTML())
   bodyHtml         String?                  @map("body_html")

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { AuthModule } from './modules/auth/auth.module.js';
 import { CaslModule } from './modules/casl/casl.module.js';
 import { UsersModule } from './modules/users/users.module.js';
 import { PagesModule } from './modules/pages/pages.module.js';
+import { NewsModule } from './modules/news/news.module.js';
 import { RedisThrottlerStorage } from './common/throttler-storage.js';
 
 @Module({
@@ -121,8 +122,9 @@ import { RedisThrottlerStorage } from './common/throttler-storage.js';
     // ── User management (SUPER_ADMIN only) ────────────────
     UsersModule,
 
-    // ── Content management ─────────────────────────────────
+    // ── Content management ─────────────────────────────
     PagesModule,
+    NewsModule,
 
     // Feature modules will be added here in subsequent tasks:
     // AuthModule, UsersModule, ContentModule, SalesModule,

--- a/src/common/dto/api-response.dto.ts
+++ b/src/common/dto/api-response.dto.ts
@@ -89,6 +89,32 @@ export function ApiResponseDto<T extends object>(DataClass: new (...args: unknow
 }
 
 /**
+ * Returns a Swagger-annotated class that describes a non-paginated list response:
+ *   { success: true, data: <DataClass>[], meta: { timestamp, path } }
+ *
+ * @example
+ *   @ApiOkResponse({ type: ApiArrayResponseDto(CardDto) })
+ */
+export function ApiArrayResponseDto<T extends object>(DataClass: new (...args: unknown[]) => T) {
+  class ArrayWrapper {
+    @ApiProperty({ example: true })
+    success!: boolean;
+
+    @ApiProperty({ type: DataClass, isArray: true })
+    data!: T[];
+
+    @ApiProperty({ type: ApiMetaDto })
+    meta!: ApiMetaDto;
+  }
+
+  Object.defineProperty(ArrayWrapper, 'name', {
+    value: `ApiArrayResponseDto_${DataClass.name}`,
+  });
+
+  return ArrayWrapper;
+}
+
+/**
  * Returns a Swagger-annotated class that describes a paginated list response:
  *   { success: true, data: <DataClass>[], meta: { timestamp, path, total, page, perPage, totalPages } }
  *

--- a/src/common/pipes/parse-slug.pipe.ts
+++ b/src/common/pipes/parse-slug.pipe.ts
@@ -1,0 +1,21 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+
+/** Matches the slug format enforced by CreatePageDto: 1–100 lowercase letters, digits, or hyphens. */
+const SLUG_RE = /^[a-z0-9]([a-z0-9-]{0,98}[a-z0-9])?$/;
+
+/**
+ * Validates a URL path parameter as a well-formed slug.
+ * Returns a 400 Bad Request for any value that does not match the format,
+ * preventing garbage input from reaching the database query layer.
+ */
+@Injectable()
+export class ParseSlugPipe implements PipeTransform<string, string> {
+  transform(value: string): string {
+    if (!SLUG_RE.test(value)) {
+      throw new BadRequestException(
+        `Invalid slug: must contain only lowercase letters, digits, or hyphens (1–100 chars)`,
+      );
+    }
+    return value;
+  }
+}

--- a/src/common/tiptap/extensions.spec.ts
+++ b/src/common/tiptap/extensions.spec.ts
@@ -49,17 +49,32 @@ describe('tiptap extensions helpers', () => {
       ],
     };
 
-    generateHtmlMock.mockReturnValue('<rendered-html />');
+    generateHtmlMock.mockReturnValue(
+      '<h2 class="text-center">Release notes</h2><p>Read the <a href="https://example.com">full article</a></p>',
+    );
 
     const html = renderToHtml(content);
 
-    expect(html).toBe('<rendered-html />');
+    expect(html).toBe(
+      '<h2 class="text-center">Release notes</h2><p>Read the <a href="https://example.com" rel="noopener noreferrer">full article</a></p>',
+    );
     expect(generateHtmlMock).toHaveBeenCalledTimes(1);
     expect(generateHtmlMock).toHaveBeenCalledWith(content, expect.any(Array));
 
     const [, extensions] = generateHtmlMock.mock.calls[0] ?? [];
 
     expect(extensions).toHaveLength(TIPTAP_EXTENSIONS.length);
+  });
+
+  it('strips XSS payloads from generateHTML output', () => {
+    const content: JSONContent = { type: 'doc', content: [] };
+    generateHtmlMock.mockReturnValue('<p onclick="alert(1)">Click</p><script>evil()</script>');
+
+    const html = renderToHtml(content);
+
+    expect(html).not.toContain('onclick');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('<p>Click</p>');
   });
 
   it('extracts plain text for FTS with stable block separators', () => {

--- a/src/common/tiptap/extensions.ts
+++ b/src/common/tiptap/extensions.ts
@@ -1,4 +1,4 @@
-import { Editor, type AnyExtension, type JSONContent } from '@tiptap/core';
+import { generateText, type AnyExtension, type JSONContent } from '@tiptap/core';
 import Color from '@tiptap/extension-color';
 import Highlight from '@tiptap/extension-highlight';
 import Image from '@tiptap/extension-image';
@@ -7,6 +7,7 @@ import TextAlign from '@tiptap/extension-text-align';
 import { TextStyle } from '@tiptap/extension-text-style';
 import { generateHTML } from '@tiptap/html/server';
 import StarterKit from '@tiptap/starter-kit';
+import sanitizeHtml from 'sanitize-html';
 
 const EMPTY_DOCUMENT: JSONContent = {
   type: 'doc',
@@ -30,6 +31,72 @@ export const TIPTAP_EXTENSIONS: readonly AnyExtension[] = Object.freeze([
   TableKit.configure({ table: { resizable: false } }),
 ]);
 
+/**
+ * Strict allowlist for HTML produced by Tiptap's generateHTML.
+ * Covers all elements the extension set above can emit.
+ * Blocks every attribute not in the list — including on*, srcdoc, data:.
+ */
+const TIPTAP_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    // StarterKit (Prose)
+    'p',
+    'br',
+    'hr',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'ul',
+    'ol',
+    'li',
+    'blockquote',
+    'pre',
+    'code',
+    'strong',
+    'em',
+    's',
+    'a',
+    // TextStyle / Color / Highlight
+    'span',
+    'mark',
+    // Image
+    'img',
+    // TableKit
+    'table',
+    'colgroup',
+    'col',
+    'thead',
+    'tbody',
+    'tfoot',
+    'tr',
+    'th',
+    'td',
+  ],
+  allowedAttributes: {
+    '*': ['class', 'style'],
+    a: ['href', 'title', 'target', 'rel'],
+    img: ['src', 'alt', 'title', 'width', 'height'],
+    col: ['span'],
+    th: ['colspan', 'rowspan', 'scope'],
+    td: ['colspan', 'rowspan'],
+  },
+  allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+  allowedSchemesByTag: { img: ['http', 'https'] },
+  allowedStyles: {
+    '*': {
+      // Allow inline color / background-color (Color + Highlight extensions)
+      color: [/.*/],
+      'background-color': [/.*/],
+      'text-align': [/^(left|center|right|justify)$/],
+    },
+  },
+  transformTags: {
+    a: sanitizeHtml.simpleTransform('a', { rel: 'noopener noreferrer' }, true),
+  },
+};
+
 export interface PlainTextExtractionOptions {
   blockSeparator?: string;
 }
@@ -51,32 +118,18 @@ function normalizeDocument(content: JSONContent | null | undefined): JSONContent
   return content;
 }
 
-function withEditor<T>(content: JSONContent | null | undefined, reader: (editor: Editor) => T): T {
-  const editor = new Editor({
-    element: null,
-    editable: false,
-    extensions: [...TIPTAP_EXTENSIONS],
-    content: normalizeDocument(content),
-  });
-
-  try {
-    return reader(editor);
-  } finally {
-    editor.destroy();
-  }
-}
-
 export function renderToHtml(content: JSONContent | null | undefined): string {
-  return generateHTML(normalizeDocument(content), [...TIPTAP_EXTENSIONS]);
+  const raw = generateHTML(normalizeDocument(content), [...TIPTAP_EXTENSIONS]);
+  return sanitizeHtml(raw, TIPTAP_SANITIZE_OPTIONS);
 }
 
 export function extractPlainText(
   content: JSONContent | null | undefined,
   options: PlainTextExtractionOptions = {},
 ): string {
-  return withEditor(content, (editor) =>
-    editor.getText({ blockSeparator: options.blockSeparator ?? '\n\n' }).trim(),
-  );
+  return generateText(normalizeDocument(content), [...TIPTAP_EXTENSIONS], {
+    blockSeparator: options.blockSeparator ?? '\n\n',
+  }).trim();
 }
 
 export function buildPublishedRichTextProjection(

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ async function bootstrap() {
   app.enableCors({
     origin: corsOrigins,
     credentials: true,
-    methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
   });
 

--- a/src/modules/news/dto/create-card.dto.ts
+++ b/src/modules/news/dto/create-card.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsInt, IsObject, IsOptional, Min } from 'class-validator';
+import { ArticleCardType } from '../../../generated/prisma/enums.js';
+
+export class CreateCardDto {
+  @ApiProperty({
+    enum: ArticleCardType,
+    example: 'TEXT',
+    description: 'Card type — determines the shape of the data payload',
+  })
+  @IsEnum(ArticleCardType)
+  type!: ArticleCardType;
+
+  @ApiPropertyOptional({
+    minimum: 0,
+    description:
+      'Insertion order (0-based). If omitted, the card is appended at the end of the list.',
+  })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  order?: number;
+
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: true,
+    description:
+      'Card content payload — shape depends on `type`. Validated server-side by Zod.\n' +
+      '  TEXT:        { body: JSONContent }   — Tiptap ProseMirror document\n' +
+      '  QUOTE:       { text: string }\n' +
+      '  PUBLICATION: { articleId: string }   — UUID of referenced NewsArticle\n' +
+      '  IMAGE:       { url: string; caption?: string }\n' +
+      '  VIDEO:       { url: string; caption?: string }',
+  })
+  @IsObject()
+  data!: Record<string, unknown>;
+}

--- a/src/modules/news/dto/create-news.dto.ts
+++ b/src/modules/news/dto/create-news.dto.ts
@@ -1,0 +1,205 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUrl,
+  IsUUID,
+  Length,
+  Matches,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { ArticleType } from '../../../generated/prisma/enums.js';
+
+// ─── Social meta per platform ─────────────────────────────────────────────────
+
+class SocialPlatformMetaDto {
+  @ApiPropertyOptional({ example: 'Заголовок для Facebook' })
+  @IsString()
+  @IsOptional()
+  @Length(0, 300)
+  title?: string;
+
+  @ApiPropertyOptional({ example: 'Текст для Facebook' })
+  @IsString()
+  @IsOptional()
+  @Length(0, 5000)
+  text?: string;
+
+  @ApiPropertyOptional({ example: 'https://example.com/image.jpg' })
+  @IsUrl({ protocols: ['http', 'https'], require_protocol: true })
+  @IsOptional()
+  imageUrl?: string;
+}
+
+class SocialMetaDto {
+  @ApiPropertyOptional({ type: SocialPlatformMetaDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SocialPlatformMetaDto)
+  facebook?: SocialPlatformMetaDto;
+
+  @ApiPropertyOptional({ type: SocialPlatformMetaDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SocialPlatformMetaDto)
+  vk?: SocialPlatformMetaDto;
+
+  @ApiPropertyOptional({ type: SocialPlatformMetaDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SocialPlatformMetaDto)
+  telegram?: SocialPlatformMetaDto;
+
+  @ApiPropertyOptional({ type: SocialPlatformMetaDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SocialPlatformMetaDto)
+  seo?: SocialPlatformMetaDto;
+}
+
+// ─── CreateNewsDto ────────────────────────────────────────────────────────────
+
+export class CreateNewsDto {
+  @ApiProperty({ example: 'Пандемия ударила по компаниям практически всех отраслей' })
+  @IsString()
+  @Length(1, 500)
+  title!: string;
+
+  /**
+   * Optional URL slug. If omitted the service auto-generates one from the title
+   * via transliteration + slugification.
+   */
+  @ApiPropertyOptional({
+    example: 'pandemiya-udarila-po-kompaniyam',
+    description:
+      'URL-safe slug: 1–200 lowercase letters, digits, or hyphens. Auto-generated from title if omitted.',
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^[a-z0-9]([a-z0-9-]{0,198}[a-z0-9])?$/, {
+    message:
+      'slug must start and end with a letter or digit, contain only lowercase letters, digits, or hyphens (1–200 chars)',
+  })
+  slug?: string;
+
+  @ApiPropertyOptional({
+    enum: ArticleType,
+    example: ArticleType.NEWS,
+    default: ArticleType.NEWS,
+  })
+  @IsEnum(ArticleType)
+  @IsOptional()
+  articleType?: ArticleType;
+
+  @ApiPropertyOptional({
+    example: '550e8400-e29b-41d4-a716-446655440001',
+    description: 'Rubric (section) UUID',
+  })
+  @IsUUID()
+  @IsOptional()
+  rubricId?: string;
+
+  @ApiPropertyOptional({ example: '2021-10-05T00:00:00.000Z' })
+  @IsDateString()
+  @IsOptional()
+  publishedAt?: string;
+
+  // ─── Anons / excerpt block ──────────────────────────────────────────────────
+
+  @ApiPropertyOptional({ example: 'Кризис обнажил уязвимость цифровой экономики' })
+  @IsString()
+  @IsOptional()
+  @Length(0, 500)
+  excerptTitle?: string;
+
+  @ApiPropertyOptional({ example: 'Краткое описание для анонсирования публикации...' })
+  @IsString()
+  @IsOptional()
+  @Length(0, 2000)
+  excerpt?: string;
+
+  @ApiPropertyOptional({ example: 'https://example.com/excerpt-image.jpg' })
+  @IsUrl({ protocols: ['http', 'https'], require_protocol: true })
+  @IsOptional()
+  excerptImage?: string;
+
+  @ApiPropertyOptional({ example: 'https://example.com/cover.jpg' })
+  @IsUrl({ protocols: ['http', 'https'], require_protocol: true })
+  @IsOptional()
+  coverImage?: string;
+
+  // ─── Author ─────────────────────────────────────────────────────────────────
+
+  @ApiPropertyOptional({
+    example: '550e8400-e29b-41d4-a716-446655440002',
+    description: 'Author user UUID. Defaults to the authenticated actor if omitted.',
+  })
+  @IsUUID()
+  @IsOptional()
+  authorId?: string;
+
+  // ─── Social meta ─────────────────────────────────────────────────────────────
+
+  @ApiPropertyOptional({ type: SocialMetaDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SocialMetaDto)
+  socialMeta?: SocialMetaDto;
+
+  // ─── RSS toggles ─────────────────────────────────────────────────────────────
+
+  @ApiPropertyOptional({ default: false })
+  @IsBoolean()
+  @IsOptional()
+  rssGoogleNews?: boolean;
+
+  @ApiPropertyOptional({ default: false })
+  @IsBoolean()
+  @IsOptional()
+  rssYandexDzen?: boolean;
+
+  @ApiPropertyOptional({ default: false })
+  @IsBoolean()
+  @IsOptional()
+  rssYandexNews?: boolean;
+
+  @ApiPropertyOptional({ default: false })
+  @IsBoolean()
+  @IsOptional()
+  rssDefault?: boolean;
+
+  // ─── Editorial controls ───────────────────────────────────────────────────────
+
+  @ApiPropertyOptional({ example: 500, default: 500, minimum: 1, maximum: 9999 })
+  @IsInt()
+  @Min(1)
+  @Max(9999)
+  @IsOptional()
+  publicationIndex?: number;
+
+  // ─── Advertisement ────────────────────────────────────────────────────────────
+
+  @ApiPropertyOptional({
+    example: '<script>/* ad tag */</script>',
+    description:
+      'Raw ad-tag banner code. MUST be rendered inside a sandboxed iframe — never injected directly into the DOM.',
+  })
+  @IsString()
+  @MaxLength(20_000)
+  @IsOptional()
+  adBannerCode?: string;
+
+  @ApiPropertyOptional({ example: 'https://example.com/ad-banner.jpg' })
+  @IsUrl({ protocols: ['http', 'https'], require_protocol: true })
+  @IsOptional()
+  adBannerImage?: string;
+}

--- a/src/modules/news/dto/list-news-query.dto.ts
+++ b/src/modules/news/dto/list-news-query.dto.ts
@@ -1,0 +1,41 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsInt, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ContentStatus, ArticleType } from '../../../generated/prisma/enums.js';
+
+export class ListNewsQueryDto {
+  @ApiPropertyOptional({ enum: ContentStatus, description: 'Filter by lifecycle status' })
+  @IsEnum(ContentStatus)
+  @IsOptional()
+  status?: ContentStatus;
+
+  @ApiPropertyOptional({ enum: ArticleType, description: 'Filter by article type' })
+  @IsEnum(ArticleType)
+  @IsOptional()
+  articleType?: ArticleType;
+
+  @ApiPropertyOptional({ description: 'Filter by rubric UUID' })
+  @IsUUID()
+  @IsOptional()
+  rubricId?: string;
+
+  @ApiPropertyOptional({ description: 'Full-text search query', example: 'цифровая экономика' })
+  @IsString()
+  @IsOptional()
+  q?: string;
+
+  @ApiPropertyOptional({ minimum: 1, default: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page?: number;
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 100, default: 20 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  perPage?: number;
+}

--- a/src/modules/news/dto/news-response.dto.ts
+++ b/src/modules/news/dto/news-response.dto.ts
@@ -1,0 +1,124 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type {
+  ArticleCardType,
+  ArticleType,
+  ContentStatus,
+} from '../../../generated/prisma/enums.js';
+
+// ─── Card response ────────────────────────────────────────────────────────────
+
+export class CardResponseDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440010' })
+  id!: string;
+
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  articleId!: string;
+
+  @ApiProperty({
+    enum: ['TEXT', 'QUOTE', 'PUBLICATION', 'IMAGE', 'VIDEO'],
+    example: 'TEXT',
+  })
+  type!: ArticleCardType;
+
+  @ApiProperty({ example: 0 })
+  order!: number;
+
+  @ApiProperty({ type: 'object', additionalProperties: true })
+  data!: Record<string, unknown>;
+
+  @ApiProperty({ example: '2026-01-01T00:00:00.000Z' })
+  createdAt!: string;
+
+  @ApiProperty({ example: '2026-01-01T00:00:00.000Z' })
+  updatedAt!: string;
+}
+
+// ─── News article summary (list / create response) ────────────────────────────
+
+export class NewsSummaryResponseDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  id!: string;
+
+  @ApiProperty({ example: 'pandemiya-udarila-po-kompaniyam' })
+  slug!: string;
+
+  @ApiProperty({ example: 'Пандемия ударила по компаниям практически всех отраслей' })
+  title!: string;
+
+  @ApiProperty({ enum: ['NEWS', 'ARTICLE', 'PRESS_RELEASE', 'INTERVIEW', 'ANNOUNCEMENT'] })
+  articleType!: ArticleType;
+
+  @ApiPropertyOptional({ example: '550e8400-e29b-41d4-a716-446655440001', nullable: true })
+  rubricId!: string | null;
+
+  @ApiProperty({ enum: ['DRAFT', 'PUBLISHED', 'ARCHIVED'] })
+  status!: ContentStatus;
+
+  @ApiPropertyOptional({ example: '2021-10-05T00:00:00.000Z', nullable: true })
+  publishedAt!: string | null;
+
+  @ApiPropertyOptional({ example: 'https://example.com/cover.jpg', nullable: true })
+  coverImage!: string | null;
+
+  @ApiPropertyOptional({ example: 'Краткий анонс...', nullable: true })
+  excerptTitle!: string | null;
+
+  @ApiProperty({ example: 500 })
+  publicationIndex!: number;
+
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440002' })
+  authorId!: string;
+
+  @ApiProperty({ example: '2026-01-01T00:00:00.000Z' })
+  createdAt!: string;
+
+  @ApiProperty({ example: '2026-01-01T00:00:00.000Z' })
+  updatedAt!: string;
+}
+
+// ─── Full news article (findOne / publish / archive response) ─────────────────
+
+export class NewsResponseDto extends NewsSummaryResponseDto {
+  @ApiPropertyOptional({ nullable: true, example: 'Краткий анонс публикации' })
+  excerpt!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, example: 'https://example.com/excerpt.jpg' })
+  excerptImage!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, example: 'https://example.com/cover.jpg' })
+  coverImageFull!: string | null;
+
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true, nullable: true })
+  socialMeta!: Record<string, unknown> | null;
+
+  @ApiProperty()
+  rssGoogleNews!: boolean;
+
+  @ApiProperty()
+  rssYandexDzen!: boolean;
+
+  @ApiProperty()
+  rssYandexNews!: boolean;
+
+  @ApiProperty()
+  rssDefault!: boolean;
+
+  @ApiPropertyOptional({ nullable: true })
+  adBannerCode!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  adBannerImage!: string | null;
+
+  @ApiProperty({ type: [CardResponseDto] })
+  cards!: CardResponseDto[];
+}
+
+// ─── Preview response (read-only; bodyHtml compiled on-the-fly) ───────────────
+
+export class NewsPreviewResponseDto extends NewsResponseDto {
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Pre-rendered HTML of all cards (generated on-the-fly for preview)',
+  })
+  bodyHtml!: string | null;
+}

--- a/src/modules/news/dto/reorder-cards.dto.ts
+++ b/src/modules/news/dto/reorder-cards.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayMinSize, ArrayUnique, IsArray, IsString } from 'class-validator';
+
+/**
+ * PUT /admin/content/news/:articleId/cards/order
+ *
+ * Accepts a complete ordered list of card IDs.  The service replaces the
+ * current order with the positions implied by array index.
+ * All IDs must belong to the specified article; any missing or foreign IDs
+ * result in a 400 Bad Request.
+ */
+export class ReorderCardsDto {
+  @ApiProperty({
+    type: [String],
+    example: ['card-uuid-3', 'card-uuid-1', 'card-uuid-2'],
+    description:
+      'Complete ordered array of card UUIDs for the article. ' +
+      'Position in the array determines the new `order` value (0-based).',
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayUnique()
+  @IsString({ each: true })
+  cardIds!: string[];
+}

--- a/src/modules/news/dto/update-card.dto.ts
+++ b/src/modules/news/dto/update-card.dto.ts
@@ -1,0 +1,28 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsObject, IsOptional, Min } from 'class-validator';
+
+/**
+ * PATCH /admin/content/news/:articleId/cards/:cardId
+ *
+ * Note: card `type` is immutable after creation — changing the type would
+ * silently invalidate the existing data payload.
+ */
+export class UpdateCardDto {
+  @ApiPropertyOptional({
+    minimum: 0,
+    description: 'New position in the ordered card list (0-based).',
+  })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  order?: number;
+
+  @ApiPropertyOptional({
+    type: 'object',
+    additionalProperties: true,
+    description: 'Updated card content payload. Must match the shape for the card type.',
+  })
+  @IsObject()
+  @IsOptional()
+  data?: Record<string, unknown>;
+}

--- a/src/modules/news/dto/update-news.dto.ts
+++ b/src/modules/news/dto/update-news.dto.ts
@@ -1,0 +1,8 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateNewsDto } from './create-news.dto.js';
+
+/**
+ * All fields from CreateNewsDto are optional in an update.
+ * PartialType preserves Swagger and class-validator decorators.
+ */
+export class UpdateNewsDto extends PartialType(CreateNewsDto) {}

--- a/src/modules/news/index.ts
+++ b/src/modules/news/index.ts
@@ -1,0 +1,2 @@
+export { NewsModule } from './news.module.js';
+export { NewsService } from './news.service.js';

--- a/src/modules/news/news.controller.ts
+++ b/src/modules/news/news.controller.ts
@@ -1,0 +1,323 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import {
+  ApiErrorResponseDto,
+  ApiPaginatedResponseDto,
+  ApiResponseDto,
+} from '../../common/dto/api-response.dto.js';
+import { CheckPolicies } from '../casl/decorators/check-policies.decorator.js';
+import { CurrentUser, type AuthenticatedUser } from '../auth/decorators/current-user.decorator.js';
+import { NewsService } from './news.service.js';
+import { CreateNewsDto } from './dto/create-news.dto.js';
+import { UpdateNewsDto } from './dto/update-news.dto.js';
+import { ListNewsQueryDto } from './dto/list-news-query.dto.js';
+import { CreateCardDto } from './dto/create-card.dto.js';
+import { UpdateCardDto } from './dto/update-card.dto.js';
+import { ReorderCardsDto } from './dto/reorder-cards.dto.js';
+import {
+  CardResponseDto,
+  NewsPreviewResponseDto,
+  NewsResponseDto,
+  NewsSummaryResponseDto,
+} from './dto/news-response.dto.js';
+
+/**
+ * Manages news articles and their content cards in the admin panel.
+ *
+ * CASL policy matrix:
+ *   GET         /                            → read  NewsArticle  (CM, SM, SA)
+ *   POST        /                            → create NewsArticle (CM, SA)
+ *   GET         /:id                         → read  NewsArticle  (CM, SM, SA)
+ *   PATCH       /:id                         → update NewsArticle (CM, SA)
+ *   DELETE      /:id                         → delete NewsArticle (CM, SA)
+ *   POST        /:id/publish                 → publish NewsArticle(CM, SA)
+ *   POST        /:id/draft                   → update NewsArticle (CM, SA)
+ *   POST        /:id/archive                 → archive NewsArticle(CM, SA)
+ *   GET         /:id/preview                 → read  NewsArticle  (CM, SM, SA)
+ *   GET         /:articleId/cards            → read  NewsArticle  (CM, SM, SA)
+ *   POST        /:articleId/cards            → update NewsArticle (CM, SA)
+ *   PATCH       /:articleId/cards/:cardId    → update NewsArticle (CM, SA)
+ *   DELETE      /:articleId/cards/:cardId    → delete NewsArticle (CM, SA)
+ *   PUT         /:articleId/cards/order      → update NewsArticle (CM, SA)
+ *
+ * All routes sit behind the global JwtAuthGuard + PoliciesGuard.
+ */
+@ApiTags('admin/content/news')
+@ApiBearerAuth('access-token')
+@Controller('admin/content/news')
+export class NewsController {
+  constructor(private readonly newsService: NewsService) {}
+
+  // ─── List ─────────────────────────────────────────────────────────────────
+
+  @Get()
+  @CheckPolicies((ability) => ability.can('read', 'NewsArticle'))
+  @ApiOperation({
+    summary: 'List news articles (paginated). Filter by status, type, rubric, text.',
+  })
+  @ApiOkResponse({ type: ApiPaginatedResponseDto(NewsSummaryResponseDto) })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  findAll(@Query() query: ListNewsQueryDto) {
+    return this.newsService.findAll(query);
+  }
+
+  // ─── Create ───────────────────────────────────────────────────────────────
+
+  @Post()
+  @CheckPolicies((ability) => ability.can('create', 'NewsArticle'))
+  @ApiOperation({ summary: 'Create a new article (starts as DRAFT).' })
+  @ApiCreatedResponse({ type: ApiResponseDto(NewsSummaryResponseDto) })
+  @ApiBadRequestResponse({ type: ApiErrorResponseDto, description: 'Validation failed' })
+  @ApiConflictResponse({ type: ApiErrorResponseDto, description: 'Slug already in use' })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  create(
+    @Body() dto: CreateNewsDto,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<NewsSummaryResponseDto> {
+    return this.newsService.create(dto, actor);
+  }
+
+  // ─── Find one ─────────────────────────────────────────────────────────────
+
+  @Get(':id')
+  @CheckPolicies((ability) => ability.can('read', 'NewsArticle'))
+  @ApiOperation({ summary: 'Get a single article with all its cards.' })
+  @ApiParam({ name: 'id', description: 'Article UUID' })
+  @ApiOkResponse({ type: ApiResponseDto(NewsResponseDto) })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  findOne(@Param('id') id: string): Promise<NewsResponseDto> {
+    return this.newsService.findOne(id);
+  }
+
+  // ─── Update metadata ──────────────────────────────────────────────────────
+
+  @Patch(':id')
+  @CheckPolicies((ability) => ability.can('update', 'NewsArticle'))
+  @ApiOperation({ summary: 'Update article metadata (title, anons, social meta, RSS, etc.).' })
+  @ApiParam({ name: 'id', description: 'Article UUID' })
+  @ApiOkResponse({ type: ApiResponseDto(NewsSummaryResponseDto) })
+  @ApiBadRequestResponse({ type: ApiErrorResponseDto })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiConflictResponse({ type: ApiErrorResponseDto, description: 'Slug already in use' })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateNewsDto,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<NewsSummaryResponseDto> {
+    return this.newsService.update(id, dto, actor);
+  }
+
+  // ─── Soft delete ──────────────────────────────────────────────────────────
+
+  @Delete(':id')
+  @CheckPolicies((ability) => ability.can('delete', 'NewsArticle'))
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Soft-delete an article (sets deletedAt; reversible via support).' })
+  @ApiParam({ name: 'id', description: 'Article UUID' })
+  @ApiNoContentResponse({ description: 'Article soft-deleted' })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  softDelete(@Param('id') id: string, @CurrentUser() actor: AuthenticatedUser): Promise<void> {
+    return this.newsService.softDelete(id, actor);
+  }
+
+  // ─── Lifecycle: publish ───────────────────────────────────────────────────
+
+  @Post(':id/publish')
+  @CheckPolicies((ability) => ability.can('publish', 'NewsArticle'))
+  @ApiOperation({
+    summary:
+      'Publish article (DRAFT/ARCHIVED → PUBLISHED). Triggers dual-write of bodyHtml + bodyText.',
+  })
+  @ApiParam({ name: 'id', description: 'Article UUID' })
+  @ApiOkResponse({ type: ApiResponseDto(NewsResponseDto) })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiConflictResponse({ type: ApiErrorResponseDto, description: 'Already published' })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  publish(
+    @Param('id') id: string,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<NewsResponseDto> {
+    return this.newsService.publish(id, actor);
+  }
+
+  // ─── Lifecycle: revert to draft ───────────────────────────────────────────
+
+  @Post(':id/draft')
+  @CheckPolicies((ability) => ability.can('update', 'NewsArticle'))
+  @ApiOperation({ summary: 'Revert published article back to DRAFT for further editing.' })
+  @ApiParam({ name: 'id', description: 'Article UUID' })
+  @ApiOkResponse({ type: ApiResponseDto(NewsResponseDto) })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiConflictResponse({ type: ApiErrorResponseDto, description: 'Article is not published' })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  revertToDraft(
+    @Param('id') id: string,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<NewsResponseDto> {
+    return this.newsService.revertToDraft(id, actor);
+  }
+
+  // ─── Lifecycle: archive ───────────────────────────────────────────────────
+
+  @Post(':id/archive')
+  @CheckPolicies((ability) => ability.can('archive', 'NewsArticle'))
+  @ApiOperation({ summary: 'Archive a published article (PUBLISHED → ARCHIVED).' })
+  @ApiParam({ name: 'id', description: 'Article UUID' })
+  @ApiOkResponse({ type: ApiResponseDto(NewsResponseDto) })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiConflictResponse({ type: ApiErrorResponseDto, description: 'Article is not published' })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  archive(
+    @Param('id') id: string,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<NewsResponseDto> {
+    return this.newsService.archive(id, actor);
+  }
+
+  // ─── Preview ──────────────────────────────────────────────────────────────
+
+  @Get(':id/preview')
+  @CheckPolicies((ability) => ability.can('read', 'NewsArticle'))
+  @ApiOperation({
+    summary: 'Preview an article with on-the-fly compiled bodyHtml (works for DRAFT articles).',
+  })
+  @ApiParam({ name: 'id', description: 'Article UUID' })
+  @ApiOkResponse({ type: ApiResponseDto(NewsPreviewResponseDto) })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  preview(@Param('id') id: string): Promise<NewsPreviewResponseDto> {
+    return this.newsService.getPreview(id);
+  }
+
+  // ─── Cards: list ─────────────────────────────────────────────────────────
+
+  @Get(':articleId/cards')
+  @CheckPolicies((ability) => ability.can('read', 'NewsArticle'))
+  @ApiOperation({ summary: 'List all cards of an article ordered by position.' })
+  @ApiParam({ name: 'articleId', description: 'Article UUID' })
+  @ApiOkResponse({ type: CardResponseDto, isArray: true })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  findCards(@Param('articleId') articleId: string): Promise<CardResponseDto[]> {
+    return this.newsService.findCards(articleId);
+  }
+
+  // ─── Cards: create ────────────────────────────────────────────────────────
+
+  @Post(':articleId/cards')
+  @CheckPolicies((ability) => ability.can('update', 'NewsArticle'))
+  @ApiOperation({ summary: 'Add a new content card to an article.' })
+  @ApiParam({ name: 'articleId', description: 'Article UUID' })
+  @ApiCreatedResponse({ type: ApiResponseDto(CardResponseDto) })
+  @ApiBadRequestResponse({ type: ApiErrorResponseDto, description: 'Invalid card data payload' })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  createCard(
+    @Param('articleId') articleId: string,
+    @Body() dto: CreateCardDto,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<CardResponseDto> {
+    return this.newsService.createCard(articleId, dto, actor);
+  }
+
+  // ─── Cards: update ────────────────────────────────────────────────────────
+
+  @Patch(':articleId/cards/:cardId')
+  @CheckPolicies((ability) => ability.can('update', 'NewsArticle'))
+  @ApiOperation({ summary: "Update a card's content or position." })
+  @ApiParam({ name: 'articleId', description: 'Article UUID' })
+  @ApiParam({ name: 'cardId', description: 'Card UUID' })
+  @ApiOkResponse({ type: ApiResponseDto(CardResponseDto) })
+  @ApiBadRequestResponse({ type: ApiErrorResponseDto })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  updateCard(
+    @Param('articleId') articleId: string,
+    @Param('cardId') cardId: string,
+    @Body() dto: UpdateCardDto,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<CardResponseDto> {
+    return this.newsService.updateCard(articleId, cardId, dto, actor);
+  }
+
+  // ─── Cards: delete ────────────────────────────────────────────────────────
+
+  @Delete(':articleId/cards/:cardId')
+  @CheckPolicies((ability) => ability.can('update', 'NewsArticle'))
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove a card from an article.' })
+  @ApiParam({ name: 'articleId', description: 'Article UUID' })
+  @ApiParam({ name: 'cardId', description: 'Card UUID' })
+  @ApiNoContentResponse({ description: 'Card deleted' })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  deleteCard(
+    @Param('articleId') articleId: string,
+    @Param('cardId') cardId: string,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<void> {
+    return this.newsService.deleteCard(articleId, cardId, actor);
+  }
+
+  // ─── Cards: reorder ───────────────────────────────────────────────────────
+
+  @Put(':articleId/cards/order')
+  @CheckPolicies((ability) => ability.can('update', 'NewsArticle'))
+  @ApiOperation({
+    summary: 'Reorder all cards of an article. Provide the complete ordered list of card UUIDs.',
+  })
+  @ApiParam({ name: 'articleId', description: 'Article UUID' })
+  @ApiOkResponse({ type: CardResponseDto, isArray: true })
+  @ApiBadRequestResponse({ type: ApiErrorResponseDto, description: 'Missing or foreign card IDs' })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
+  @ApiForbiddenResponse({ type: ApiErrorResponseDto })
+  reorderCards(
+    @Param('articleId') articleId: string,
+    @Body() dto: ReorderCardsDto,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<CardResponseDto[]> {
+    return this.newsService.reorderCards(articleId, dto, actor);
+  }
+}

--- a/src/modules/news/news.controller.ts
+++ b/src/modules/news/news.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseUUIDPipe,
   Patch,
   Post,
   Put,
@@ -26,6 +27,7 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import {
+  ApiArrayResponseDto,
   ApiErrorResponseDto,
   ApiPaginatedResponseDto,
   ApiResponseDto,
@@ -114,7 +116,7 @@ export class NewsController {
   @ApiNotFoundResponse({ type: ApiErrorResponseDto })
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
-  findOne(@Param('id') id: string): Promise<NewsResponseDto> {
+  findOne(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string): Promise<NewsResponseDto> {
     return this.newsService.findOne(id);
   }
 
@@ -131,7 +133,7 @@ export class NewsController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   update(
-    @Param('id') id: string,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
     @Body() dto: UpdateNewsDto,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<NewsSummaryResponseDto> {
@@ -149,7 +151,10 @@ export class NewsController {
   @ApiNotFoundResponse({ type: ApiErrorResponseDto })
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
-  softDelete(@Param('id') id: string, @CurrentUser() actor: AuthenticatedUser): Promise<void> {
+  softDelete(
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<void> {
     return this.newsService.softDelete(id, actor);
   }
 
@@ -168,7 +173,7 @@ export class NewsController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   publish(
-    @Param('id') id: string,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<NewsResponseDto> {
     return this.newsService.publish(id, actor);
@@ -186,7 +191,7 @@ export class NewsController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   revertToDraft(
-    @Param('id') id: string,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<NewsResponseDto> {
     return this.newsService.revertToDraft(id, actor);
@@ -204,7 +209,7 @@ export class NewsController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   archive(
-    @Param('id') id: string,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<NewsResponseDto> {
     return this.newsService.archive(id, actor);
@@ -222,7 +227,9 @@ export class NewsController {
   @ApiNotFoundResponse({ type: ApiErrorResponseDto })
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
-  preview(@Param('id') id: string): Promise<NewsPreviewResponseDto> {
+  preview(
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+  ): Promise<NewsPreviewResponseDto> {
     return this.newsService.getPreview(id);
   }
 
@@ -232,11 +239,13 @@ export class NewsController {
   @CheckPolicies((ability) => ability.can('read', 'NewsArticle'))
   @ApiOperation({ summary: 'List all cards of an article ordered by position.' })
   @ApiParam({ name: 'articleId', description: 'Article UUID' })
-  @ApiOkResponse({ type: CardResponseDto, isArray: true })
+  @ApiOkResponse({ type: ApiArrayResponseDto(CardResponseDto) })
   @ApiNotFoundResponse({ type: ApiErrorResponseDto })
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
-  findCards(@Param('articleId') articleId: string): Promise<CardResponseDto[]> {
+  findCards(
+    @Param('articleId', new ParseUUIDPipe({ version: '4' })) articleId: string,
+  ): Promise<CardResponseDto[]> {
     return this.newsService.findCards(articleId);
   }
 
@@ -252,7 +261,7 @@ export class NewsController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   createCard(
-    @Param('articleId') articleId: string,
+    @Param('articleId', new ParseUUIDPipe({ version: '4' })) articleId: string,
     @Body() dto: CreateCardDto,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<CardResponseDto> {
@@ -272,8 +281,8 @@ export class NewsController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   updateCard(
-    @Param('articleId') articleId: string,
-    @Param('cardId') cardId: string,
+    @Param('articleId', new ParseUUIDPipe({ version: '4' })) articleId: string,
+    @Param('cardId', new ParseUUIDPipe({ version: '4' })) cardId: string,
     @Body() dto: UpdateCardDto,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<CardResponseDto> {
@@ -293,8 +302,8 @@ export class NewsController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   deleteCard(
-    @Param('articleId') articleId: string,
-    @Param('cardId') cardId: string,
+    @Param('articleId', new ParseUUIDPipe({ version: '4' })) articleId: string,
+    @Param('cardId', new ParseUUIDPipe({ version: '4' })) cardId: string,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<void> {
     return this.newsService.deleteCard(articleId, cardId, actor);
@@ -308,13 +317,13 @@ export class NewsController {
     summary: 'Reorder all cards of an article. Provide the complete ordered list of card UUIDs.',
   })
   @ApiParam({ name: 'articleId', description: 'Article UUID' })
-  @ApiOkResponse({ type: CardResponseDto, isArray: true })
+  @ApiOkResponse({ type: ApiArrayResponseDto(CardResponseDto) })
   @ApiBadRequestResponse({ type: ApiErrorResponseDto, description: 'Missing or foreign card IDs' })
   @ApiNotFoundResponse({ type: ApiErrorResponseDto })
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   reorderCards(
-    @Param('articleId') articleId: string,
+    @Param('articleId', new ParseUUIDPipe({ version: '4' })) articleId: string,
     @Body() dto: ReorderCardsDto,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<CardResponseDto[]> {

--- a/src/modules/news/news.module.ts
+++ b/src/modules/news/news.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { AuditModule } from '../audit/audit.module.js';
+import { NewsController } from './news.controller.js';
+import { NewsService } from './news.service.js';
+
+/**
+ * NewsModule manages news articles and their content cards.
+ *
+ * Auth:   JwtAuthGuard (global, from AuthModule)
+ * RBAC:   PoliciesGuard (global, from CaslModule) + @CheckPolicies per route
+ * Audit:  AuditModule (async BullMQ-backed operational audit log)
+ * Prisma: PrismaModule (global — no explicit import needed)
+ */
+@Module({
+  imports: [AuditModule],
+  controllers: [NewsController],
+  providers: [NewsService],
+})
+export class NewsModule {}

--- a/src/modules/news/news.service.spec.ts
+++ b/src/modules/news/news.service.spec.ts
@@ -125,6 +125,7 @@ describe('NewsService', () => {
             },
             $transaction: jest.fn(),
             $queryRaw: jest.fn(),
+            $executeRaw: jest.fn().mockResolvedValue(undefined),
           },
         },
         {
@@ -503,7 +504,7 @@ describe('NewsService', () => {
         actor,
       );
 
-      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
       expect(result).toHaveLength(3);
     });
 

--- a/src/modules/news/news.service.spec.ts
+++ b/src/modules/news/news.service.spec.ts
@@ -1,0 +1,558 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { NewsService } from './news.service.js';
+import { PrismaService } from '../../prisma/prisma.service.js';
+import { AuditService } from '../audit/audit.service.js';
+import { ArticleCardType, ArticleType, ContentStatus, Role } from '../../generated/prisma/enums.js';
+import type { AuthenticatedUser } from '../auth/decorators/current-user.decorator.js';
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+jest.mock('../../generated/prisma/client.js', () => {
+  class PrismaClientKnownRequestError extends Error {
+    code: string;
+    constructor(message: string, { code }: { code: string }) {
+      super(message);
+      this.code = code;
+      this.name = 'PrismaClientKnownRequestError';
+    }
+  }
+  return {
+    PrismaClient: jest.fn(),
+    Prisma: {
+      PrismaClientKnownRequestError,
+      QueryMode: { insensitive: 'insensitive' },
+      sql: jest.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
+      join: jest.fn((values: unknown[], separator: unknown) => ({ values, separator })),
+    },
+  };
+});
+jest.mock('@prisma/adapter-pg', () => ({ PrismaPg: jest.fn() }));
+jest.mock('pg', () => ({ Pool: jest.fn() }));
+
+// Mock Tiptap server rendering — isolates service from DOM/editor deps
+jest.mock('../../common/tiptap/extensions.js', () => ({
+  renderToHtml: jest.fn(() => '<p>Rendered HTML</p>'),
+  extractPlainText: jest.fn(() => 'Plain text'),
+}));
+
+const { Prisma } = jest.requireMock('../../generated/prisma/client.js') as {
+  Prisma: {
+    PrismaClientKnownRequestError: new (
+      msg: string,
+      meta: { code: string },
+    ) => Error & { code: string };
+  };
+};
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const now = new Date('2026-03-13T00:00:00.000Z');
+
+const actor: AuthenticatedUser = {
+  id: 'user-uuid-1',
+  email: 'admin@example.com',
+  role: Role.SUPER_ADMIN,
+};
+
+const articleSummaryRow = {
+  id: 'article-uuid-1',
+  slug: 'test-article',
+  title: 'Test Article',
+  articleType: ArticleType.NEWS,
+  rubricId: null,
+  status: ContentStatus.DRAFT,
+  publishedAt: null,
+  coverImage: null,
+  excerptTitle: null,
+  publicationIndex: 500,
+  authorId: 'user-uuid-1',
+  createdAt: now,
+  updatedAt: now,
+};
+
+const articleFullRow = {
+  ...articleSummaryRow,
+  excerpt: null,
+  excerptImage: null,
+  socialMeta: null,
+  rssGoogleNews: false,
+  rssYandexDzen: false,
+  rssYandexNews: false,
+  rssDefault: false,
+  adBannerCode: null,
+  adBannerImage: null,
+};
+
+const textCardRow = {
+  id: 'card-uuid-1',
+  articleId: 'article-uuid-1',
+  type: ArticleCardType.TEXT,
+  order: 0,
+  data: { body: { type: 'doc', content: [] } },
+  createdAt: now,
+  updatedAt: now,
+};
+
+// ─── Test setup ───────────────────────────────────────────────────────────────
+
+describe('NewsService', () => {
+  let service: NewsService;
+  let prisma: jest.Mocked<PrismaService>;
+  let auditService: jest.Mocked<AuditService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NewsService,
+        {
+          provide: PrismaService,
+          useValue: {
+            newsArticle: {
+              create: jest.fn(),
+              findMany: jest.fn(),
+              findFirst: jest.fn(),
+              findUnique: jest.fn(),
+              update: jest.fn(),
+              count: jest.fn(),
+            },
+            articleCard: {
+              create: jest.fn(),
+              findMany: jest.fn(),
+              findFirst: jest.fn(),
+              update: jest.fn(),
+              delete: jest.fn(),
+            },
+            $transaction: jest.fn(),
+            $queryRaw: jest.fn(),
+          },
+        },
+        {
+          provide: AuditService,
+          useValue: { logAsync: jest.fn().mockResolvedValue(undefined) },
+        },
+      ],
+    }).compile();
+
+    service = module.get(NewsService);
+    prisma = module.get(PrismaService) as jest.Mocked<PrismaService>;
+    auditService = module.get(AuditService) as jest.Mocked<AuditService>;
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ─── create ──────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('creates a DRAFT article and returns the summary', async () => {
+      (prisma.newsArticle.findUnique as jest.Mock).mockResolvedValue(null); // slug available
+      (prisma.newsArticle.create as jest.Mock).mockResolvedValue(articleSummaryRow);
+
+      const result = await service.create({ title: 'Test Article' }, actor);
+
+      expect(prisma.newsArticle.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: 'Test Article',
+            status: ContentStatus.DRAFT,
+          }),
+        }),
+      );
+      expect(result.status).toBe(ContentStatus.DRAFT);
+      expect(auditService.logAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('auto-generates a slug when none is provided', async () => {
+      (prisma.newsArticle.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.newsArticle.create as jest.Mock).mockResolvedValue({
+        ...articleSummaryRow,
+        slug: 'test-article',
+      });
+
+      const result = await service.create({ title: 'Тест статья' }, actor);
+      expect(result.slug).toBeDefined();
+    });
+
+    it('appends a numeric suffix when the slug is already taken', async () => {
+      // First call (base slug) exists; second call (slug-2) is free
+      (prisma.newsArticle.findUnique as jest.Mock)
+        .mockResolvedValueOnce({ id: 'other-uuid' }) // base slug taken
+        .mockResolvedValueOnce(null); // slug-2 free
+      (prisma.newsArticle.create as jest.Mock).mockResolvedValue({
+        ...articleSummaryRow,
+        slug: 'test-article-2',
+      });
+
+      await service.create({ title: 'Test Article' }, actor);
+      expect(prisma.newsArticle.create).toHaveBeenCalled();
+    });
+
+    it('throws ConflictException on P2002 unique violation', async () => {
+      (prisma.newsArticle.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.newsArticle.create as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Unique constraint', { code: 'P2002' }),
+      );
+
+      await expect(service.create({ title: 'Test Article', slug: 'taken' }, actor)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('rejects unsafe ad banner code payloads', async () => {
+      await expect(
+        service.create(
+          {
+            title: 'Test Article',
+            adBannerCode: '<iframe srcdoc="<script>alert(1)</script>"></iframe>',
+          },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── findAll ─────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('returns a paginated result excluding soft-deleted articles', async () => {
+      (prisma.newsArticle.findMany as jest.Mock).mockResolvedValue([articleSummaryRow]);
+      (prisma.newsArticle.count as jest.Mock).mockResolvedValue(1);
+
+      const result = await service.findAll({ page: 1, perPage: 20 });
+
+      expect(prisma.newsArticle.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ deletedAt: null }) }),
+      );
+      expect(result.data).toHaveLength(1);
+      expect(result.meta.total).toBe(1);
+    });
+
+    it('filters by status when provided', async () => {
+      (prisma.newsArticle.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.newsArticle.count as jest.Mock).mockResolvedValue(0);
+
+      await service.findAll({ status: ContentStatus.PUBLISHED });
+
+      expect(prisma.newsArticle.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: ContentStatus.PUBLISHED,
+            deletedAt: null,
+          }),
+        }),
+      );
+    });
+  });
+
+  // ─── findOne ─────────────────────────────────────────────────────────────
+
+  describe('findOne', () => {
+    it('returns the article with cards', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(articleFullRow);
+      (prisma.articleCard.findMany as jest.Mock).mockResolvedValue([textCardRow]);
+
+      const result = await service.findOne('article-uuid-1');
+
+      expect(result.id).toBe('article-uuid-1');
+      expect(result.cards).toHaveLength(1);
+    });
+
+    it('throws NotFoundException for unknown id', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.findOne('ghost-uuid')).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException for soft-deleted article', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(null); // filtered by deletedAt
+
+      await expect(service.findOne('deleted-uuid')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── softDelete ───────────────────────────────────────────────────────────
+
+  describe('softDelete', () => {
+    it('sets deletedAt on the article', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(articleSummaryRow);
+      (prisma.newsArticle.update as jest.Mock).mockResolvedValue({
+        ...articleSummaryRow,
+        deletedAt: new Date(),
+      });
+
+      await service.softDelete('article-uuid-1', actor);
+
+      expect(prisma.newsArticle.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ deletedAt: expect.any(Date) }) }),
+      );
+      expect(auditService.logAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws NotFoundException when article does not exist', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.softDelete('ghost-uuid', actor)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── publish ─────────────────────────────────────────────────────────────
+
+  describe('publish', () => {
+    it('publishes a DRAFT article and dual-writes bodyHtml + bodyText', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(articleSummaryRow);
+      (prisma.articleCard.findMany as jest.Mock).mockResolvedValue([textCardRow]);
+      const publishedRow = {
+        ...articleFullRow,
+        status: ContentStatus.PUBLISHED,
+        publishedAt: now,
+        bodyHtml: '<p>Rendered HTML</p>',
+        bodyText: 'Plain text',
+      };
+      (prisma.newsArticle.update as jest.Mock).mockResolvedValue(publishedRow);
+
+      const result = await service.publish('article-uuid-1', actor);
+
+      expect(prisma.newsArticle.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: ContentStatus.PUBLISHED,
+            bodyHtml: expect.any(String),
+            bodyText: expect.any(String),
+          }),
+        }),
+      );
+      expect(result.status).toBe(ContentStatus.PUBLISHED);
+      expect(auditService.logAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws ConflictException when article is already published', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue({
+        ...articleSummaryRow,
+        status: ContentStatus.PUBLISHED,
+      });
+      (prisma.articleCard.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.newsArticle.update as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Record not found', { code: 'P2025' }),
+      );
+      (prisma.newsArticle.findUnique as jest.Mock).mockResolvedValue({
+        status: ContentStatus.PUBLISHED,
+      });
+
+      await expect(service.publish('article-uuid-1', actor)).rejects.toThrow(ConflictException);
+    });
+
+    it('throws NotFoundException when article does not exist', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.publish('ghost-uuid', actor)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── archive ─────────────────────────────────────────────────────────────
+
+  describe('archive', () => {
+    it('archives a published article', async () => {
+      const publishedRow = { ...articleSummaryRow, status: ContentStatus.PUBLISHED };
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(publishedRow);
+      (prisma.newsArticle.update as jest.Mock).mockResolvedValue({
+        ...articleFullRow,
+        status: ContentStatus.ARCHIVED,
+      });
+      (prisma.articleCard.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.archive('article-uuid-1', actor);
+      expect(result.status).toBe(ContentStatus.ARCHIVED);
+    });
+
+    it('throws ConflictException when article is not published', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(articleSummaryRow); // DRAFT
+      (prisma.newsArticle.update as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Record not found', { code: 'P2025' }),
+      );
+
+      await expect(service.archive('article-uuid-1', actor)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  // ─── getPreview ───────────────────────────────────────────────────────────
+
+  describe('getPreview', () => {
+    it('returns article with on-the-fly bodyHtml for DRAFT', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(articleFullRow);
+      (prisma.articleCard.findMany as jest.Mock).mockResolvedValue([textCardRow]);
+
+      const result = await service.getPreview('article-uuid-1');
+
+      expect(result.status).toBe(ContentStatus.DRAFT);
+      expect(result.bodyHtml).toBeDefined();
+    });
+  });
+
+  // ─── createCard ───────────────────────────────────────────────────────────
+
+  describe('createCard', () => {
+    it('creates a TEXT card with valid Tiptap body', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue({
+        id: 'article-uuid-1',
+        status: ContentStatus.DRAFT,
+      });
+      (prisma.articleCard.findMany as jest.Mock).mockResolvedValueOnce([]);
+      (prisma.articleCard.create as jest.Mock).mockResolvedValue(textCardRow);
+      (prisma.articleCard.findFirst as jest.Mock).mockResolvedValue(textCardRow);
+      (prisma.$transaction as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await service.createCard(
+        'article-uuid-1',
+        {
+          type: ArticleCardType.TEXT,
+          data: { body: { type: 'doc', content: [] } },
+        },
+        actor,
+      );
+
+      expect(result.type).toBe(ArticleCardType.TEXT);
+      expect(prisma.articleCard.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws BadRequestException for invalid TEXT card data', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue({
+        id: 'article-uuid-1',
+        status: ContentStatus.DRAFT,
+      });
+
+      await expect(
+        service.createCard(
+          'article-uuid-1',
+          { type: ArticleCardType.TEXT, data: { body: { type: 'paragraph' } } }, // wrong root type
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException for invalid IMAGE url (non-http)', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue({
+        id: 'article-uuid-1',
+        status: ContentStatus.DRAFT,
+      });
+
+      await expect(
+        service.createCard(
+          'article-uuid-1',
+          { type: ArticleCardType.IMAGE, data: { url: 'javascript:alert(1)' } },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when article does not exist', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.createCard(
+          'ghost-uuid',
+          { type: ArticleCardType.QUOTE, data: { text: 'Hello' } },
+          actor,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ConflictException when trying to edit cards of a published article', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue({
+        id: 'article-uuid-1',
+        status: ContentStatus.PUBLISHED,
+      });
+
+      await expect(
+        service.createCard(
+          'article-uuid-1',
+          { type: ArticleCardType.QUOTE, data: { text: 'Hello' } },
+          actor,
+        ),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  // ─── reorderCards ─────────────────────────────────────────────────────────
+
+  describe('reorderCards', () => {
+    const cards = [
+      { id: 'card-uuid-1', order: 0 },
+      { id: 'card-uuid-2', order: 1 },
+      { id: 'card-uuid-3', order: 2 },
+    ];
+
+    it('reorders cards transactionally', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue({
+        id: 'article-uuid-1',
+        status: ContentStatus.DRAFT,
+      });
+      (prisma.articleCard.findMany as jest.Mock)
+        .mockResolvedValueOnce(cards) // existing
+        .mockResolvedValueOnce(
+          [...cards].reverse().map((c, i) => ({
+            ...textCardRow,
+            id: c.id,
+            order: i,
+          })),
+        ); // after reorder
+      (prisma.$transaction as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await service.reorderCards(
+        'article-uuid-1',
+        { cardIds: ['card-uuid-3', 'card-uuid-2', 'card-uuid-1'] },
+        actor,
+      );
+
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(3);
+    });
+
+    it('throws BadRequestException for foreign card IDs', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue({
+        id: 'article-uuid-1',
+        status: ContentStatus.DRAFT,
+      });
+      (prisma.articleCard.findMany as jest.Mock).mockResolvedValue(cards);
+
+      await expect(
+        service.reorderCards(
+          'article-uuid-1',
+          { cardIds: ['card-uuid-1', 'card-uuid-2', 'foreign-uuid'] },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when card list is incomplete', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue({
+        id: 'article-uuid-1',
+        status: ContentStatus.DRAFT,
+      });
+      (prisma.articleCard.findMany as jest.Mock).mockResolvedValue(cards);
+
+      await expect(
+        service.reorderCards(
+          'article-uuid-1',
+          { cardIds: ['card-uuid-1', 'card-uuid-2'] }, // missing card-uuid-3
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when card list contains duplicates', async () => {
+      (prisma.newsArticle.findFirst as jest.Mock).mockResolvedValue({
+        id: 'article-uuid-1',
+        status: ContentStatus.DRAFT,
+      });
+      (prisma.articleCard.findMany as jest.Mock).mockResolvedValue(cards);
+
+      await expect(
+        service.reorderCards(
+          'article-uuid-1',
+          { cardIds: ['card-uuid-1', 'card-uuid-1', 'card-uuid-2'] },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/src/modules/news/news.service.ts
+++ b/src/modules/news/news.service.ts
@@ -1,0 +1,1169 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ZodError } from 'zod';
+import { Prisma } from '../../generated/prisma/client.js';
+import {
+  AuditAction,
+  AuditResourceType,
+  ArticleCardType,
+  ArticleType,
+  ContentStatus,
+} from '../../generated/prisma/enums.js';
+import { PrismaService } from '../../prisma/prisma.service.js';
+import { AuditService } from '../audit/audit.service.js';
+import type { AuthenticatedUser } from '../auth/decorators/current-user.decorator.js';
+import {
+  paginatedResult,
+  type PaginatedResult,
+} from '../../common/interceptors/transform-response.interceptor.js';
+import { renderToHtml, extractPlainText } from '../../common/tiptap/extensions.js';
+import type { JSONContent } from '@tiptap/core';
+import {
+  validateCardData,
+  type TextCardData,
+  type QuoteCardData,
+  type PublicationCardData,
+  type ImageCardData,
+  type VideoCardData,
+} from './schemas/card-data.schema.js';
+import type { CreateNewsDto } from './dto/create-news.dto.js';
+import type { UpdateNewsDto } from './dto/update-news.dto.js';
+import type { ListNewsQueryDto } from './dto/list-news-query.dto.js';
+import type { CreateCardDto } from './dto/create-card.dto.js';
+import type { UpdateCardDto } from './dto/update-card.dto.js';
+import type { ReorderCardsDto } from './dto/reorder-cards.dto.js';
+import type {
+  CardResponseDto,
+  NewsPreviewResponseDto,
+  NewsResponseDto,
+  NewsSummaryResponseDto,
+} from './dto/news-response.dto.js';
+
+const CARD_ORDER_TEMP_OFFSET = 1_000_000;
+
+// ─── Cyrillic transliteration map ────────────────────────────────────────────
+
+const CYRILLIC_MAP: Record<string, string> = {
+  а: 'a',
+  б: 'b',
+  в: 'v',
+  г: 'g',
+  д: 'd',
+  е: 'e',
+  ё: 'yo',
+  ж: 'zh',
+  з: 'z',
+  и: 'i',
+  й: 'j',
+  к: 'k',
+  л: 'l',
+  м: 'm',
+  н: 'n',
+  о: 'o',
+  п: 'p',
+  р: 'r',
+  с: 's',
+  т: 't',
+  у: 'u',
+  ф: 'f',
+  х: 'kh',
+  ц: 'ts',
+  ч: 'ch',
+  ш: 'sh',
+  щ: 'shch',
+  ъ: '',
+  ы: 'y',
+  ь: '',
+  э: 'e',
+  ю: 'yu',
+  я: 'ya',
+};
+
+function slugify(text: string): string {
+  return (
+    text
+      .toLowerCase()
+      .split('')
+      .map((c) => CYRILLIC_MAP[c] ?? c)
+      .join('')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 200) || 'article'
+  );
+}
+
+// ─── Prisma select shapes ─────────────────────────────────────────────────────
+
+const ARTICLE_SUMMARY_SELECT = {
+  id: true,
+  slug: true,
+  title: true,
+  articleType: true,
+  rubricId: true,
+  status: true,
+  publishedAt: true,
+  coverImage: true,
+  excerptTitle: true,
+  publicationIndex: true,
+  authorId: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+const ARTICLE_FULL_SELECT = {
+  ...ARTICLE_SUMMARY_SELECT,
+  excerpt: true,
+  excerptImage: true,
+  socialMeta: true,
+  rssGoogleNews: true,
+  rssYandexDzen: true,
+  rssYandexNews: true,
+  rssDefault: true,
+  adBannerCode: true,
+  adBannerImage: true,
+} as const;
+
+const CARD_SELECT = {
+  id: true,
+  articleId: true,
+  type: true,
+  order: true,
+  data: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+// ─── Row types ────────────────────────────────────────────────────────────────
+
+type ArticleSummaryRow = {
+  id: string;
+  slug: string;
+  title: string;
+  articleType: ArticleType;
+  rubricId: string | null;
+  status: ContentStatus;
+  publishedAt: Date | null;
+  coverImage: string | null;
+  excerptTitle: string | null;
+  publicationIndex: number;
+  authorId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type ArticleFullRow = ArticleSummaryRow & {
+  excerpt: string | null;
+  excerptImage: string | null;
+  socialMeta: Prisma.JsonValue;
+  rssGoogleNews: boolean;
+  rssYandexDzen: boolean;
+  rssYandexNews: boolean;
+  rssDefault: boolean;
+  adBannerCode: string | null;
+  adBannerImage: string | null;
+};
+
+type CardRow = {
+  id: string;
+  articleId: string;
+  type: ArticleCardType;
+  order: number;
+  data: Prisma.JsonValue;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+// ─── Mappers ──────────────────────────────────────────────────────────────────
+
+function mapCard(row: CardRow): CardResponseDto {
+  return {
+    id: row.id,
+    articleId: row.articleId,
+    type: row.type,
+    order: row.order,
+    data: row.data as Record<string, unknown>,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function mapSummary(row: ArticleSummaryRow): NewsSummaryResponseDto {
+  return {
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    articleType: row.articleType,
+    rubricId: row.rubricId,
+    status: row.status,
+    publishedAt: row.publishedAt?.toISOString() ?? null,
+    coverImage: row.coverImage,
+    excerptTitle: row.excerptTitle,
+    publicationIndex: row.publicationIndex,
+    authorId: row.authorId,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function mapFull(row: ArticleFullRow, cards: CardRow[]): NewsResponseDto {
+  return {
+    ...mapSummary(row),
+    excerpt: row.excerpt,
+    excerptImage: row.excerptImage,
+    coverImageFull: row.coverImage,
+    socialMeta: row.socialMeta as Record<string, unknown> | null,
+    rssGoogleNews: row.rssGoogleNews,
+    rssYandexDzen: row.rssYandexDzen,
+    rssYandexNews: row.rssYandexNews,
+    rssDefault: row.rssDefault,
+    adBannerCode: row.adBannerCode,
+    adBannerImage: row.adBannerImage,
+    cards: cards.map(mapCard),
+  };
+}
+
+function toAuditSnapshot(row: ArticleSummaryRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    status: row.status,
+    authorId: row.authorId,
+    publishedAt: row.publishedAt?.toISOString() ?? null,
+  };
+}
+
+// ─── HTML/Text compilation from cards ────────────────────────────────────────
+
+/**
+ * Escapes a plain string for safe HTML insertion.
+ * Used only for QUOTE card text — no external HTML is constructed from user input.
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function normalizeAdBannerCode(code: string): string {
+  const normalized = code.trim();
+
+  const blockedPattern =
+    /<\/?(?:iframe|object|embed|meta|base|form|input|button|textarea|select)\b|\s+on[a-z]+\s*=|javascript\s*:|\bsrcdoc\s*=/i;
+  if (blockedPattern.test(normalized)) {
+    throw new BadRequestException(
+      'adBannerCode contains disallowed HTML or script constructs; only sandboxed ad tag snippets are accepted',
+    );
+  }
+
+  return normalized;
+}
+
+interface CompiledBody {
+  bodyHtml: string;
+  bodyText: string;
+  /** Combined Tiptap JSON from all TEXT cards (stored as NewsArticle.body). */
+  tiptapBody: JSONContent;
+}
+
+/**
+ * Compiles ordered ArticleCard rows into bodyHtml, bodyText, and tiptapBody.
+ * For PUBLICATION cards, look-up data must be pre-fetched and passed in `pubMap`.
+ */
+function compileCards(
+  cards: CardRow[],
+  pubMap: Map<string, { title: string; coverImage: string | null; slug: string }>,
+): CompiledBody {
+  const htmlParts: string[] = [];
+  const textParts: string[] = [];
+  const tiptapContent: JSONContent['content'] = [];
+
+  for (const card of cards) {
+    const data = card.data as Record<string, unknown>;
+
+    switch (card.type) {
+      case ArticleCardType.TEXT: {
+        const tData = data as TextCardData;
+        const html = renderToHtml(tData.body as JSONContent);
+        const text = extractPlainText(tData.body as JSONContent);
+        htmlParts.push(html);
+        textParts.push(text);
+        // Collect top-level nodes for the combined Tiptap document
+        const bodyContent = (tData.body as JSONContent).content;
+        if (Array.isArray(bodyContent)) {
+          tiptapContent.push(...bodyContent);
+        }
+        break;
+      }
+
+      case ArticleCardType.QUOTE: {
+        const qData = data as QuoteCardData;
+        htmlParts.push(`<blockquote><p>${escapeHtml(qData.text)}</p></blockquote>`);
+        textParts.push(qData.text);
+        break;
+      }
+
+      case ArticleCardType.PUBLICATION: {
+        const pData = data as PublicationCardData;
+        const ref = pubMap.get(pData.articleId);
+        if (ref) {
+          const imgTag = ref.coverImage
+            ? `<img src="${escapeHtml(ref.coverImage)}" alt="${escapeHtml(ref.title)}" loading="lazy">`
+            : '';
+          htmlParts.push(
+            `<div class="embedded-publication"><a href="/press/${escapeHtml(ref.slug)}">${imgTag}<span>${escapeHtml(ref.title)}</span></a></div>`,
+          );
+          textParts.push(ref.title);
+        }
+        break;
+      }
+
+      case ArticleCardType.IMAGE: {
+        const iData = data as ImageCardData;
+        const caption = iData.caption ? escapeHtml(iData.caption) : '';
+        htmlParts.push(
+          `<figure><img src="${escapeHtml(iData.url)}" alt="${caption}" loading="lazy">${caption ? `<figcaption>${caption}</figcaption>` : ''}</figure>`,
+        );
+        if (iData.caption) textParts.push(iData.caption);
+        break;
+      }
+
+      case ArticleCardType.VIDEO: {
+        const vData = data as VideoCardData;
+        const caption = vData.caption ? escapeHtml(vData.caption) : '';
+        htmlParts.push(
+          `<div class="video-embed"><a href="${escapeHtml(vData.url)}" target="_blank" rel="noopener noreferrer">${caption || vData.url}</a></div>`,
+        );
+        if (vData.caption) textParts.push(vData.caption);
+        break;
+      }
+    }
+  }
+
+  return {
+    bodyHtml: htmlParts.join('\n'),
+    bodyText: textParts.join('\n\n'),
+    tiptapBody: { type: 'doc', content: tiptapContent },
+  };
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+/**
+ * NewsService manages the full lifecycle of news articles and their content cards.
+ *
+ * Key invariants:
+ *  - NewsArticle.slug is UNIQUE; auto-generated from title if not provided.
+ *  - Soft delete: deletedAt is set instead of hard deletion; all queries filter it.
+ *  - Publish dual-write: on publish, cards are compiled into bodyHtml + bodyText + body.
+ *  - Cards are ordered by the `order` field; reorder is a transactional bulk update.
+ *  - Card data is Zod-validated per type before any DB write.
+ */
+@Injectable()
+export class NewsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+  ) {}
+
+  // ─── Article CRUD ─────────────────────────────────────────────────────────
+
+  async create(dto: CreateNewsDto, actor: AuthenticatedUser): Promise<NewsSummaryResponseDto> {
+    const baseSlug = dto.slug ?? slugify(dto.title);
+    const slug = await this.ensureUniqueSlug(baseSlug);
+
+    const article = await this.prisma.newsArticle
+      .create({
+        data: {
+          title: dto.title,
+          slug,
+          articleType: dto.articleType ?? ArticleType.NEWS,
+          rubricId: dto.rubricId ?? null,
+          excerptTitle: dto.excerptTitle ?? null,
+          excerpt: dto.excerpt ?? null,
+          excerptImage: dto.excerptImage ?? null,
+          coverImage: dto.coverImage ?? null,
+          status: ContentStatus.DRAFT,
+          publishedAt: dto.publishedAt ? new Date(dto.publishedAt) : null,
+          socialMeta:
+            dto.socialMeta != null ? (dto.socialMeta as Prisma.InputJsonValue) : Prisma.JsonNull,
+          rssGoogleNews: dto.rssGoogleNews ?? false,
+          rssYandexDzen: dto.rssYandexDzen ?? false,
+          rssYandexNews: dto.rssYandexNews ?? false,
+          rssDefault: dto.rssDefault ?? false,
+          publicationIndex: dto.publicationIndex ?? 500,
+          adBannerCode:
+            dto.adBannerCode !== undefined ? normalizeAdBannerCode(dto.adBannerCode) : null,
+          adBannerImage: dto.adBannerImage ?? null,
+          authorId: dto.authorId ?? actor.id,
+        },
+        select: ARTICLE_SUMMARY_SELECT,
+      })
+      .catch((e: unknown) => {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+          throw new ConflictException(`News article with slug "${slug}" already exists`);
+        }
+        throw e;
+      });
+
+    await this.auditService.logAsync({
+      actorId: actor.id,
+      action: AuditAction.CREATE,
+      resourceType: AuditResourceType.NewsArticle,
+      resourceId: article.id,
+      beforeSnapshot: null,
+      afterSnapshot: toAuditSnapshot(article),
+    });
+
+    return mapSummary(article);
+  }
+
+  async findAll(query: ListNewsQueryDto): Promise<PaginatedResult<NewsSummaryResponseDto>> {
+    const page = query.page ?? 1;
+    const perPage = query.perPage ?? 20;
+    const trimmedQuery = query.q?.trim();
+
+    const where: Prisma.NewsArticleWhereInput = {
+      deletedAt: null,
+      ...(query.status && { status: query.status }),
+      ...(query.articleType && { articleType: query.articleType }),
+      ...(query.rubricId && { rubricId: query.rubricId }),
+    };
+
+    if (trimmedQuery) {
+      return this.findAllByFullTextSearch({
+        where,
+        query,
+        trimmedQuery,
+        page,
+        perPage,
+      });
+    }
+
+    const [articles, total] = await Promise.all([
+      this.prisma.newsArticle.findMany({
+        where,
+        select: ARTICLE_SUMMARY_SELECT,
+        orderBy: [{ publicationIndex: 'asc' }, { createdAt: 'desc' }],
+        skip: (page - 1) * perPage,
+        take: perPage,
+      }),
+      this.prisma.newsArticle.count({ where }),
+    ]);
+
+    return paginatedResult(articles.map(mapSummary), {
+      total,
+      page,
+      perPage,
+      totalPages: Math.ceil(total / perPage),
+    });
+  }
+
+  async findOne(id: string): Promise<NewsResponseDto> {
+    const article = await this.findArticleOrThrow(id, ARTICLE_FULL_SELECT);
+    const cards = await this.prisma.articleCard.findMany({
+      where: { articleId: id },
+      select: CARD_SELECT,
+      orderBy: { order: 'asc' },
+    });
+    return mapFull(article as ArticleFullRow, cards);
+  }
+
+  async update(
+    id: string,
+    dto: UpdateNewsDto,
+    actor: AuthenticatedUser,
+  ): Promise<NewsSummaryResponseDto> {
+    const existing = await this.findArticleOrThrow(id, ARTICLE_SUMMARY_SELECT);
+    const before = toAuditSnapshot(existing);
+
+    // If caller provides a new slug, ensure it is not already taken
+    let newSlug = existing.slug;
+    if (dto.slug && dto.slug !== existing.slug) {
+      await this.assertSlugAvailable(dto.slug);
+      newSlug = dto.slug;
+    }
+
+    const data: Prisma.NewsArticleUncheckedUpdateInput = {
+      ...(dto.title !== undefined && { title: dto.title }),
+      slug: newSlug,
+      ...(dto.articleType !== undefined && { articleType: dto.articleType }),
+      ...(dto.rubricId !== undefined && { rubricId: dto.rubricId ?? null }),
+      ...(dto.excerptTitle !== undefined && { excerptTitle: dto.excerptTitle }),
+      ...(dto.excerpt !== undefined && { excerpt: dto.excerpt }),
+      ...(dto.excerptImage !== undefined && { excerptImage: dto.excerptImage }),
+      ...(dto.coverImage !== undefined && { coverImage: dto.coverImage }),
+      ...(dto.publishedAt !== undefined && {
+        publishedAt: dto.publishedAt ? new Date(dto.publishedAt) : null,
+      }),
+      ...(dto.socialMeta !== undefined && {
+        socialMeta:
+          dto.socialMeta != null ? (dto.socialMeta as Prisma.InputJsonValue) : Prisma.JsonNull,
+      }),
+      ...(dto.rssGoogleNews !== undefined && { rssGoogleNews: dto.rssGoogleNews }),
+      ...(dto.rssYandexDzen !== undefined && { rssYandexDzen: dto.rssYandexDzen }),
+      ...(dto.rssYandexNews !== undefined && { rssYandexNews: dto.rssYandexNews }),
+      ...(dto.rssDefault !== undefined && { rssDefault: dto.rssDefault }),
+      ...(dto.publicationIndex !== undefined && { publicationIndex: dto.publicationIndex }),
+      ...(dto.adBannerCode !== undefined && {
+        adBannerCode: normalizeAdBannerCode(dto.adBannerCode),
+      }),
+      ...(dto.adBannerImage !== undefined && { adBannerImage: dto.adBannerImage }),
+      ...(dto.authorId !== undefined && { authorId: dto.authorId }),
+    };
+
+    const updated = await this.prisma.newsArticle.update({
+      where: { id },
+      data,
+      select: ARTICLE_SUMMARY_SELECT,
+    });
+
+    await this.auditService.logAsync({
+      actorId: actor.id,
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.NewsArticle,
+      resourceId: id,
+      beforeSnapshot: before,
+      afterSnapshot: toAuditSnapshot(updated),
+    });
+
+    return mapSummary(updated);
+  }
+
+  /**
+   * Soft-deletes an article by setting deletedAt.
+   * Permanently retains cards in DB (cascade delete only on hard delete).
+   */
+  async softDelete(id: string, actor: AuthenticatedUser): Promise<void> {
+    const existing = await this.findArticleOrThrow(id, ARTICLE_SUMMARY_SELECT);
+
+    await this.prisma.newsArticle.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+
+    await this.auditService.logAsync({
+      actorId: actor.id,
+      action: AuditAction.DELETE,
+      resourceType: AuditResourceType.NewsArticle,
+      resourceId: id,
+      beforeSnapshot: toAuditSnapshot(existing),
+      afterSnapshot: null,
+    });
+  }
+
+  // ─── Lifecycle transitions ────────────────────────────────────────────────
+
+  /**
+   * DRAFT/ARCHIVED → PUBLISHED
+   * Dual-write: compiles cards → bodyHtml + bodyText + body (tiptap JSON).
+   */
+  async publish(id: string, actor: AuthenticatedUser): Promise<NewsResponseDto> {
+    const existing = await this.findArticleOrThrow(id, ARTICLE_SUMMARY_SELECT);
+    const before = toAuditSnapshot(existing);
+
+    const cards = await this.prisma.articleCard.findMany({
+      where: { articleId: id },
+      select: CARD_SELECT,
+      orderBy: { order: 'asc' },
+    });
+
+    // Prefetch referenced publication articles for PUBLICATION cards
+    const pubMap = await this.buildPublicationMap(cards);
+
+    const { bodyHtml, bodyText, tiptapBody } = compileCards(cards, pubMap);
+
+    const updated = await this.prisma.newsArticle
+      .update({
+        where: { id, status: { not: ContentStatus.PUBLISHED }, deletedAt: null },
+        data: {
+          status: ContentStatus.PUBLISHED,
+          publishedAt: existing.publishedAt ?? new Date(),
+          body: tiptapBody as Prisma.InputJsonValue,
+          bodyHtml,
+          bodyText,
+        },
+        select: ARTICLE_FULL_SELECT,
+      })
+      .catch(async (e: unknown) => {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+          const current = await this.prisma.newsArticle.findUnique({
+            where: { id },
+            select: { status: true },
+          });
+          if (!current) throw new NotFoundException(`News article "${id}" not found`);
+          throw new ConflictException(`News article "${id}" is already published`);
+        }
+        throw e;
+      });
+
+    await this.auditService.logAsync({
+      actorId: actor.id,
+      action: AuditAction.PUBLISH,
+      resourceType: AuditResourceType.NewsArticle,
+      resourceId: id,
+      beforeSnapshot: before,
+      afterSnapshot: toAuditSnapshot(updated as ArticleSummaryRow),
+      metadata: { cardCount: cards.length },
+    });
+
+    return mapFull(updated as ArticleFullRow, cards);
+  }
+
+  /**
+   * PUBLISHED → DRAFT  (revert to editable state)
+   */
+  async revertToDraft(id: string, actor: AuthenticatedUser): Promise<NewsResponseDto> {
+    const existing = await this.findArticleOrThrow(id, ARTICLE_SUMMARY_SELECT);
+    const before = toAuditSnapshot(existing);
+
+    const updated = await this.prisma.newsArticle
+      .update({
+        where: { id, status: ContentStatus.PUBLISHED, deletedAt: null },
+        data: { status: ContentStatus.DRAFT },
+        select: ARTICLE_FULL_SELECT,
+      })
+      .catch(async (e: unknown) => {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+          throw new ConflictException(
+            `News article "${id}" is not published — cannot revert to draft`,
+          );
+        }
+        throw e;
+      });
+
+    const cards = await this.prisma.articleCard.findMany({
+      where: { articleId: id },
+      select: CARD_SELECT,
+      orderBy: { order: 'asc' },
+    });
+
+    await this.auditService.logAsync({
+      actorId: actor.id,
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.NewsArticle,
+      resourceId: id,
+      beforeSnapshot: before,
+      afterSnapshot: toAuditSnapshot(updated as ArticleSummaryRow),
+      metadata: { transition: 'PUBLISHED→DRAFT' },
+    });
+
+    return mapFull(updated as ArticleFullRow, cards);
+  }
+
+  /**
+   * PUBLISHED → ARCHIVED
+   */
+  async archive(id: string, actor: AuthenticatedUser): Promise<NewsResponseDto> {
+    const existing = await this.findArticleOrThrow(id, ARTICLE_SUMMARY_SELECT);
+    const before = toAuditSnapshot(existing);
+
+    const updated = await this.prisma.newsArticle
+      .update({
+        where: { id, status: ContentStatus.PUBLISHED, deletedAt: null },
+        data: { status: ContentStatus.ARCHIVED },
+        select: ARTICLE_FULL_SELECT,
+      })
+      .catch(async (e: unknown) => {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+          throw new ConflictException(`News article "${id}" is not published — cannot archive`);
+        }
+        throw e;
+      });
+
+    const cards = await this.prisma.articleCard.findMany({
+      where: { articleId: id },
+      select: CARD_SELECT,
+      orderBy: { order: 'asc' },
+    });
+
+    await this.auditService.logAsync({
+      actorId: actor.id,
+      action: AuditAction.ARCHIVE,
+      resourceType: AuditResourceType.NewsArticle,
+      resourceId: id,
+      beforeSnapshot: before,
+      afterSnapshot: toAuditSnapshot(updated as ArticleSummaryRow),
+    });
+
+    return mapFull(updated as ArticleFullRow, cards);
+  }
+
+  /**
+   * Returns a read-only preview of the article with on-the-fly compiled bodyHtml.
+   * Accessible for DRAFT articles — does not require PUBLISHED status.
+   */
+  async getPreview(id: string): Promise<NewsPreviewResponseDto> {
+    const article = await this.findArticleOrThrow(id, ARTICLE_FULL_SELECT);
+    const cards = await this.prisma.articleCard.findMany({
+      where: { articleId: id },
+      select: CARD_SELECT,
+      orderBy: { order: 'asc' },
+    });
+
+    const pubMap = await this.buildPublicationMap(cards);
+    const { bodyHtml } = compileCards(cards, pubMap);
+
+    return {
+      ...mapFull(article as ArticleFullRow, cards),
+      bodyHtml,
+    };
+  }
+
+  // ─── Cards CRUD ───────────────────────────────────────────────────────────
+
+  async findCards(articleId: string): Promise<CardResponseDto[]> {
+    await this.findArticleOrThrow(articleId, { id: true } as const);
+    const cards = await this.prisma.articleCard.findMany({
+      where: { articleId },
+      select: CARD_SELECT,
+      orderBy: { order: 'asc' },
+    });
+    return cards.map(mapCard);
+  }
+
+  async createCard(
+    articleId: string,
+    dto: CreateCardDto,
+    actor: AuthenticatedUser,
+  ): Promise<CardResponseDto> {
+    await this.findMutableArticleOrThrow(articleId);
+
+    // Zod validation
+    const validatedData = this.parseCardData(dto.type, dto.data);
+    await this.assertPublicationCardReference(articleId, dto.type, validatedData);
+
+    const existingCards = await this.prisma.articleCard.findMany({
+      where: { articleId },
+      select: { id: true },
+      orderBy: { order: 'asc' },
+    });
+
+    const insertIndex = dto.order ?? existingCards.length;
+    if (insertIndex > existingCards.length) {
+      throw new BadRequestException(
+        `Card order ${insertIndex} is out of bounds for article with ${existingCards.length} cards`,
+      );
+    }
+
+    const card = await this.prisma.articleCard.create({
+      data: {
+        articleId,
+        type: dto.type,
+        order: CARD_ORDER_TEMP_OFFSET + existingCards.length,
+        data: validatedData as Prisma.InputJsonValue,
+      },
+      select: CARD_SELECT,
+    });
+
+    const orderedCardIds = existingCards.map((existingCard) => existingCard.id);
+    orderedCardIds.splice(insertIndex, 0, card.id);
+    await this.persistCardOrder(orderedCardIds);
+
+    const created = await this.findCardOrThrow(articleId, card.id);
+
+    await this.auditService.logAsync({
+      actorId: actor.id,
+      action: AuditAction.CREATE,
+      resourceType: AuditResourceType.NewsArticle,
+      resourceId: articleId,
+      beforeSnapshot: null,
+      afterSnapshot: { cardId: created.id, type: created.type, order: created.order },
+      metadata: { cardId: created.id },
+    });
+
+    return mapCard(created);
+  }
+
+  async updateCard(
+    articleId: string,
+    cardId: string,
+    dto: UpdateCardDto,
+    actor: AuthenticatedUser,
+  ): Promise<CardResponseDto> {
+    await this.findMutableArticleOrThrow(articleId);
+    const card = await this.findCardOrThrow(articleId, cardId);
+
+    // Validate updated data against the card's immutable type
+    const validatedData =
+      dto.data !== undefined ? this.parseCardData(card.type, dto.data) : undefined;
+    if (validatedData !== undefined) {
+      await this.assertPublicationCardReference(articleId, card.type, validatedData);
+      await this.prisma.articleCard.update({
+        where: { id: cardId },
+        data: {
+          data: validatedData as Prisma.InputJsonValue,
+        },
+      });
+    }
+
+    if (dto.order !== undefined && dto.order !== card.order) {
+      const existingCards = await this.prisma.articleCard.findMany({
+        where: { articleId },
+        select: { id: true },
+        orderBy: { order: 'asc' },
+      });
+
+      if (dto.order >= existingCards.length) {
+        throw new BadRequestException(
+          `Card order ${dto.order} is out of bounds for article with ${existingCards.length} cards`,
+        );
+      }
+
+      const orderedCardIds = existingCards.map((existingCard) => existingCard.id);
+      const currentIndex = orderedCardIds.indexOf(cardId);
+      orderedCardIds.splice(currentIndex, 1);
+      orderedCardIds.splice(dto.order, 0, cardId);
+      await this.persistCardOrder(orderedCardIds);
+    }
+
+    const updated = await this.findCardOrThrow(articleId, cardId);
+
+    await this.auditService.logAsync({
+      actorId: actor.id,
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.NewsArticle,
+      resourceId: articleId,
+      beforeSnapshot: { cardId, order: card.order },
+      afterSnapshot: { cardId, order: updated.order },
+      metadata: { cardId },
+    });
+
+    return mapCard(updated);
+  }
+
+  async deleteCard(articleId: string, cardId: string, actor: AuthenticatedUser): Promise<void> {
+    await this.findMutableArticleOrThrow(articleId);
+    const card = await this.findCardOrThrow(articleId, cardId);
+
+    await this.prisma.articleCard.delete({ where: { id: cardId } });
+
+    const remainingCardIds = (
+      await this.prisma.articleCard.findMany({
+        where: { articleId },
+        select: { id: true },
+        orderBy: { order: 'asc' },
+      })
+    ).map((remainingCard) => remainingCard.id);
+    await this.persistCardOrder(remainingCardIds);
+
+    await this.auditService.logAsync({
+      actorId: actor.id,
+      action: AuditAction.DELETE,
+      resourceType: AuditResourceType.NewsArticle,
+      resourceId: articleId,
+      beforeSnapshot: { cardId, type: card.type, order: card.order },
+      afterSnapshot: null,
+      metadata: { cardId },
+    });
+  }
+
+  /**
+   * Atomically replaces card order values based on the submitted cardIds array.
+   * Position in the array = new order value (0-based).
+   * All provided cardIds must belong to the given article.
+   */
+  async reorderCards(
+    articleId: string,
+    dto: ReorderCardsDto,
+    actor: AuthenticatedUser,
+  ): Promise<CardResponseDto[]> {
+    await this.findMutableArticleOrThrow(articleId);
+
+    const existing = await this.prisma.articleCard.findMany({
+      where: { articleId },
+      select: { id: true, order: true },
+      orderBy: { order: 'asc' },
+    });
+
+    const uniqueRequestedIds = new Set(dto.cardIds);
+    if (uniqueRequestedIds.size !== dto.cardIds.length) {
+      throw new BadRequestException('Reorder list contains duplicate card IDs');
+    }
+
+    const existingIds = new Set(existing.map((c) => c.id));
+    const invalidIds = dto.cardIds.filter((cid) => !existingIds.has(cid));
+    if (invalidIds.length > 0) {
+      throw new BadRequestException(`Card IDs not found in article: ${invalidIds.join(', ')}`);
+    }
+    if (dto.cardIds.length !== existingIds.size) {
+      throw new BadRequestException(
+        `Reorder list must include all ${existingIds.size} cards of the article`,
+      );
+    }
+
+    await this.persistCardOrder(dto.cardIds);
+
+    const cards = await this.prisma.articleCard.findMany({
+      where: { articleId },
+      select: CARD_SELECT,
+      orderBy: { order: 'asc' },
+    });
+
+    await this.auditService.logAsync({
+      actorId: actor.id,
+      action: AuditAction.UPDATE,
+      resourceType: AuditResourceType.NewsArticle,
+      resourceId: articleId,
+      beforeSnapshot: { cardOrder: existing.map((c) => c.id) },
+      afterSnapshot: { cardOrder: dto.cardIds },
+      metadata: { operation: 'reorder' },
+    });
+
+    return cards.map(mapCard);
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────
+
+  private async findArticleOrThrow<S extends Prisma.NewsArticleSelect>(
+    id: string,
+    select: S,
+  ): Promise<Prisma.NewsArticleGetPayload<{ select: S }>> {
+    const article = await this.prisma.newsArticle.findFirst({
+      where: { id, deletedAt: null },
+      select,
+    });
+    if (!article) {
+      throw new NotFoundException(`News article "${id}" not found`);
+    }
+    return article;
+  }
+
+  private async findCardOrThrow(articleId: string, cardId: string): Promise<CardRow> {
+    const card = await this.prisma.articleCard.findFirst({
+      where: { id: cardId, articleId },
+      select: CARD_SELECT,
+    });
+    if (!card) {
+      throw new NotFoundException(`Card "${cardId}" not found in article "${articleId}"`);
+    }
+    return card;
+  }
+
+  private async findMutableArticleOrThrow(articleId: string): Promise<void> {
+    const article = await this.findArticleOrThrow(articleId, {
+      id: true,
+      status: true,
+    } as const);
+
+    if (article.status === ContentStatus.PUBLISHED) {
+      throw new ConflictException(
+        `News article "${articleId}" is published — revert it to draft before editing cards`,
+      );
+    }
+  }
+
+  /**
+   * Generates a unique slug by appending a short numeric suffix on conflict.
+   * Tries the base slug first, then base-2, base-3, … up to 20 attempts.
+   */
+  private async ensureUniqueSlug(base: string): Promise<string> {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const candidate = attempt === 0 ? base : `${base}-${attempt + 1}`;
+      const exists = await this.prisma.newsArticle.findUnique({
+        where: { slug: candidate },
+        select: { id: true },
+      });
+      if (!exists) return candidate;
+    }
+    // Extremely unlikely: fall back to UUID suffix
+    const { v4: uuidv4 } = await import('uuid');
+    return `${base}-${uuidv4().slice(0, 8)}`;
+  }
+
+  private async assertSlugAvailable(slug: string): Promise<void> {
+    const exists = await this.prisma.newsArticle.findUnique({
+      where: { slug },
+      select: { id: true },
+    });
+    if (exists) {
+      throw new ConflictException(`Slug "${slug}" is already in use`);
+    }
+  }
+
+  private parseCardData(type: ArticleCardType, data: unknown): Record<string, unknown> {
+    try {
+      return validateCardData(type, data) as Record<string, unknown>;
+    } catch (e) {
+      if (e instanceof ZodError) {
+        throw new BadRequestException(
+          `Invalid data for card type ${type}: ${e.errors.map((err) => err.message).join('; ')}`,
+        );
+      }
+      throw e;
+    }
+  }
+
+  private async assertPublicationCardReference(
+    articleId: string,
+    type: ArticleCardType,
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    if (type !== ArticleCardType.PUBLICATION) return;
+
+    const publicationArticleId = (data as PublicationCardData).articleId;
+    if (publicationArticleId === articleId) {
+      throw new BadRequestException('Publication cards cannot reference the same article');
+    }
+
+    const referencedArticle = await this.prisma.newsArticle.findFirst({
+      where: {
+        id: publicationArticleId,
+        deletedAt: null,
+        status: ContentStatus.PUBLISHED,
+      },
+      select: { id: true },
+    });
+
+    if (!referencedArticle) {
+      throw new BadRequestException(
+        `Publication card must reference an existing published article: ${publicationArticleId}`,
+      );
+    }
+  }
+
+  private async persistCardOrder(orderedCardIds: string[]): Promise<void> {
+    if (orderedCardIds.length === 0) return;
+
+    await this.prisma.$transaction([
+      ...orderedCardIds.map((cardId, index) =>
+        this.prisma.articleCard.update({
+          where: { id: cardId },
+          data: { order: CARD_ORDER_TEMP_OFFSET + index },
+        }),
+      ),
+      ...orderedCardIds.map((cardId, index) =>
+        this.prisma.articleCard.update({
+          where: { id: cardId },
+          data: { order: index },
+        }),
+      ),
+    ]);
+  }
+
+  private async findAllByFullTextSearch({
+    where,
+    query,
+    trimmedQuery,
+    page,
+    perPage,
+  }: {
+    where: Prisma.NewsArticleWhereInput;
+    query: ListNewsQueryDto;
+    trimmedQuery: string;
+    page: number;
+    perPage: number;
+  }): Promise<PaginatedResult<NewsSummaryResponseDto>> {
+    const filters: Prisma.Sql[] = [Prisma.sql`"deleted_at" IS NULL`];
+
+    if (query.status) {
+      filters.push(Prisma.sql`"status" = ${query.status}::"ContentStatus"`);
+    }
+    if (query.articleType) {
+      filters.push(Prisma.sql`"article_type" = ${query.articleType}::"ArticleType"`);
+    }
+    if (query.rubricId) {
+      filters.push(Prisma.sql`"rubric_id" = ${query.rubricId}`);
+    }
+    filters.push(Prisma.sql`"body_tsv" @@ websearch_to_tsquery('russian', ${trimmedQuery})`);
+
+    const whereSql = Prisma.join(filters, ' AND ');
+    const rankSql = Prisma.sql`ts_rank_cd("body_tsv", websearch_to_tsquery('russian', ${trimmedQuery}))`;
+
+    const [matchingIds, totalRows] = await Promise.all([
+      this.prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+        SELECT "id"
+        FROM "news_articles"
+        WHERE ${whereSql}
+        ORDER BY ${rankSql} DESC, "publication_index" ASC, "created_at" DESC
+        OFFSET ${(page - 1) * perPage}
+        LIMIT ${perPage}
+      `),
+      this.prisma.$queryRaw<Array<{ count: bigint | number }>>(Prisma.sql`
+        SELECT COUNT(*)::bigint AS "count"
+        FROM "news_articles"
+        WHERE ${whereSql}
+      `),
+    ]);
+
+    const orderedIds = matchingIds.map((row) => row.id);
+    const total = Number(totalRows[0]?.count ?? 0);
+
+    if (orderedIds.length === 0) {
+      return paginatedResult([], {
+        total,
+        page,
+        perPage,
+        totalPages: Math.ceil(total / perPage),
+      });
+    }
+
+    const articles = await this.prisma.newsArticle.findMany({
+      where: {
+        ...where,
+        id: { in: orderedIds },
+      },
+      select: ARTICLE_SUMMARY_SELECT,
+    });
+
+    const articlesById = new Map(articles.map((article) => [article.id, article]));
+    const orderedArticles = orderedIds
+      .map((id) => articlesById.get(id))
+      .filter((article): article is ArticleSummaryRow => article != null);
+
+    return paginatedResult(orderedArticles.map(mapSummary), {
+      total,
+      page,
+      perPage,
+      totalPages: Math.ceil(total / perPage),
+    });
+  }
+
+  /**
+   * Prefetches referenced articles for all PUBLICATION cards in a batch.
+   * Returns a map keyed by articleId.
+   */
+  private async buildPublicationMap(
+    cards: CardRow[],
+  ): Promise<Map<string, { title: string; coverImage: string | null; slug: string }>> {
+    const pubCardIds = [
+      ...new Set(
+        cards
+          .filter((c) => c.type === ArticleCardType.PUBLICATION)
+          .map((c) => (c.data as PublicationCardData).articleId),
+      ),
+    ];
+
+    if (pubCardIds.length === 0) return new Map();
+
+    const articles = await this.prisma.newsArticle.findMany({
+      where: {
+        id: { in: pubCardIds },
+        deletedAt: null,
+        status: ContentStatus.PUBLISHED,
+      },
+      select: { id: true, title: true, coverImage: true, slug: true },
+    });
+
+    if (articles.length !== pubCardIds.length) {
+      const foundArticleIds = new Set(articles.map((article) => article.id));
+      const missingArticleIds = pubCardIds.filter((articleId) => !foundArticleIds.has(articleId));
+      throw new BadRequestException(
+        `Publication cards reference unavailable articles: ${missingArticleIds.join(', ')}`,
+      );
+    }
+
+    return new Map(
+      articles.map(
+        (a) => [a.id, a] as [string, { title: string; coverImage: string | null; slug: string }],
+      ),
+    );
+  }
+}

--- a/src/modules/news/news.service.ts
+++ b/src/modules/news/news.service.ts
@@ -594,9 +594,9 @@ export class NewsService {
       })
       .catch(async (e: unknown) => {
         if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
-          const current = await this.prisma.newsArticle.findUnique({
-            where: { id },
-            select: { status: true },
+          const current = await this.prisma.newsArticle.findFirst({
+            where: { id, deletedAt: null },
+            select: { id: true },
           });
           if (!current) throw new NotFoundException(`News article "${id}" not found`);
           throw new ConflictException(`News article "${id}" is already published`);
@@ -1032,20 +1032,18 @@ export class NewsService {
   private async persistCardOrder(orderedCardIds: string[]): Promise<void> {
     if (orderedCardIds.length === 0) return;
 
-    await this.prisma.$transaction([
-      ...orderedCardIds.map((cardId, index) =>
-        this.prisma.articleCard.update({
-          where: { id: cardId },
-          data: { order: CARD_ORDER_TEMP_OFFSET + index },
-        }),
-      ),
-      ...orderedCardIds.map((cardId, index) =>
-        this.prisma.articleCard.update({
-          where: { id: cardId },
-          data: { order: index },
-        }),
-      ),
-    ]);
+    const cases = orderedCardIds.map(
+      (cardId, index) => Prisma.sql`WHEN ${cardId}::uuid THEN ${index}`,
+    );
+    const idList = Prisma.join(orderedCardIds.map((id) => Prisma.sql`${id}::uuid`));
+
+    await this.prisma.$executeRaw(Prisma.sql`
+      UPDATE "article_cards"
+      SET "order" = CASE "id"
+        ${Prisma.join(cases, ' ')}
+      END
+      WHERE "id" IN (${idList})
+    `);
   }
 
   private async findAllByFullTextSearch({

--- a/src/modules/news/schemas/card-data.schema.ts
+++ b/src/modules/news/schemas/card-data.schema.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+
+// ─── Security helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Restricts URL fields to http/https only.
+ * Rejects javascript: and other inject-prone schemes (defense-in-depth, XSS).
+ */
+const httpUrl = () =>
+  z
+    .string()
+    .url({ message: 'Must be a valid URL' })
+    .refine((u) => /^https?:\/\//i.test(u), {
+      message: 'Only http and https URLs are allowed',
+    });
+
+// ─── Card data schemas (Zod) ──────────────────────────────────────────────────
+
+/**
+ * TEXT card — Tiptap ProseMirror JSON document.
+ * Only structural type-check here; deep ProseMirror validation is deferred to
+ * the Tiptap editor on parse.  We enforce the mandatory `type: "doc"` root so
+ * obviously malformed payloads are rejected early.
+ */
+export const TextCardDataSchema = z.object({
+  body: z
+    .object({
+      type: z.literal('doc'),
+      content: z.array(z.record(z.unknown())).optional(),
+    })
+    .passthrough(),
+});
+
+/**
+ * QUOTE card — a plain-text pull-quote or blockquote.
+ */
+export const QuoteCardDataSchema = z.object({
+  text: z.string().min(1).max(5_000),
+});
+
+/**
+ * PUBLICATION card — an embedded reference to another news article.
+ * The articleId is a UUID referencing NewsArticle.id.
+ */
+export const PublicationCardDataSchema = z.object({
+  articleId: z.string().uuid({ message: 'articleId must be a valid UUID' }),
+});
+
+/**
+ * IMAGE card — a single image with an optional caption.
+ * URL must point to an http/https resource (not a data: or javascript: URI).
+ */
+export const ImageCardDataSchema = z.object({
+  url: httpUrl(),
+  caption: z.string().max(500).optional(),
+});
+
+/**
+ * VIDEO card — a video embed URL with an optional caption.
+ * Accepts any http/https URL (YouTube, Vimeo, direct MP4, etc.).
+ */
+export const VideoCardDataSchema = z.object({
+  url: httpUrl(),
+  caption: z.string().max(500).optional(),
+});
+
+// ─── Schema registry ──────────────────────────────────────────────────────────
+
+export const CARD_DATA_SCHEMAS = {
+  TEXT: TextCardDataSchema,
+  QUOTE: QuoteCardDataSchema,
+  PUBLICATION: PublicationCardDataSchema,
+  IMAGE: ImageCardDataSchema,
+  VIDEO: VideoCardDataSchema,
+} as const;
+
+export type CardType = keyof typeof CARD_DATA_SCHEMAS;
+
+export type TextCardData = z.infer<typeof TextCardDataSchema>;
+export type QuoteCardData = z.infer<typeof QuoteCardDataSchema>;
+export type PublicationCardData = z.infer<typeof PublicationCardDataSchema>;
+export type ImageCardData = z.infer<typeof ImageCardDataSchema>;
+export type VideoCardData = z.infer<typeof VideoCardDataSchema>;
+
+export type CardData =
+  | TextCardData
+  | QuoteCardData
+  | PublicationCardData
+  | ImageCardData
+  | VideoCardData;
+
+/**
+ * Validates the card data payload against the schema for the given card type.
+ * Throws a ZodError if validation fails.
+ */
+export function validateCardData(type: CardType, data: unknown): CardData {
+  return CARD_DATA_SCHEMAS[type].parse(data) as CardData;
+}

--- a/src/modules/pages/dto/create-page.dto.ts
+++ b/src/modules/pages/dto/create-page.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import { IsString, Length, Matches } from 'class-validator';
 
 export class CreatePageDto {
@@ -17,6 +18,7 @@ export class CreatePageDto {
     example: 'Акционерам и инвесторам',
     description: 'Human-readable page title displayed in the admin panel',
   })
+  @Transform(({ value }: { value: unknown }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
   @Length(1, 200)
   name!: string;

--- a/src/modules/pages/dto/update-page.dto.ts
+++ b/src/modules/pages/dto/update-page.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import { IsString, Length } from 'class-validator';
 
 export class UpdatePageDto {
@@ -6,6 +7,7 @@ export class UpdatePageDto {
     example: 'Акционерам и инвесторам',
     description: 'New human-readable page title',
   })
+  @Transform(({ value }: { value: unknown }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
   @Length(1, 200)
   name!: string;

--- a/src/modules/pages/pages.controller.ts
+++ b/src/modules/pages/pages.controller.ts
@@ -30,6 +30,7 @@ import {
 } from '../../common/dto/api-response.dto.js';
 import { CheckPolicies } from '../casl/decorators/check-policies.decorator.js';
 import { CurrentUser, type AuthenticatedUser } from '../auth/decorators/current-user.decorator.js';
+import { ParseSlugPipe } from '../../common/pipes/parse-slug.pipe.js';
 import { PagesService } from './pages.service.js';
 import { CreatePageDto } from './dto/create-page.dto.js';
 import { UpsertPageDto } from './dto/upsert-page.dto.js';
@@ -44,6 +45,7 @@ import { UpdatePageDto } from './dto/update-page.dto.js';
  *   GET  /              → read Page   → CONTENT_MANAGER, SALES_MANAGER, SUPER_ADMIN
  *   POST /              → create Page → CONTENT_MANAGER, SUPER_ADMIN
  *   GET  /:slug         → read Page   → CONTENT_MANAGER, SALES_MANAGER, SUPER_ADMIN
+ *   PATCH/:slug         → update Page → CONTENT_MANAGER, SUPER_ADMIN
  *   PUT  /:slug         → update Page → CONTENT_MANAGER, SUPER_ADMIN
  *   POST /:slug/publish → publish Page→ CONTENT_MANAGER, SUPER_ADMIN
  *   POST /:slug/archive → archive Page→ CONTENT_MANAGER, SUPER_ADMIN
@@ -96,7 +98,7 @@ export class PagesController {
   @ApiNotFoundResponse({ type: ApiErrorResponseDto, description: 'Page not found' })
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
-  findOne(@Param('slug') slug: string): Promise<PageResponseDto> {
+  findOne(@Param('slug', ParseSlugPipe) slug: string): Promise<PageResponseDto> {
     return this.pagesService.findOne(slug);
   }
 
@@ -112,7 +114,7 @@ export class PagesController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   updateName(
-    @Param('slug') slug: string,
+    @Param('slug', ParseSlugPipe) slug: string,
     @Body() dto: UpdatePageDto,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<PageSummaryResponseDto> {
@@ -139,7 +141,7 @@ export class PagesController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   replaceSections(
-    @Param('slug') slug: string,
+    @Param('slug', ParseSlugPipe) slug: string,
     @Body() dto: UpsertPageDto,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<PageResponseDto> {
@@ -159,7 +161,7 @@ export class PagesController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   publish(
-    @Param('slug') slug: string,
+    @Param('slug', ParseSlugPipe) slug: string,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<PageResponseDto> {
     return this.pagesService.publish(slug, actor);
@@ -181,7 +183,7 @@ export class PagesController {
   @ApiUnauthorizedResponse({ type: ApiErrorResponseDto })
   @ApiForbiddenResponse({ type: ApiErrorResponseDto })
   archive(
-    @Param('slug') slug: string,
+    @Param('slug', ParseSlugPipe) slug: string,
     @CurrentUser() actor: AuthenticatedUser,
   ): Promise<PageResponseDto> {
     return this.pagesService.archive(slug, actor);

--- a/src/modules/pages/pages.service.ts
+++ b/src/modules/pages/pages.service.ts
@@ -240,11 +240,18 @@ export class PagesService {
     const existing = await this.findPageOrThrow(slug);
     const before = toAuditSnapshot(existing);
 
-    const updated = await this.prisma.page.update({
-      where: { id: existing.id },
-      data: { name: dto.name },
-      select: PAGE_SELECT,
-    });
+    const updated = await this.prisma.page
+      .update({
+        where: { id: existing.id },
+        data: { name: dto.name },
+        select: PAGE_SELECT,
+      })
+      .catch(async (e: unknown) => {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+          throw new NotFoundException(`Page "${slug}" not found`);
+        }
+        throw e;
+      });
 
     await this.auditService.logAsync({
       actorId: actor.id,
@@ -464,6 +471,7 @@ export class PagesService {
       try {
         return await this.prisma.$transaction(operation, {
           isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+          timeout: 30_000,
         });
       } catch (error) {
         if (

--- a/src/modules/pages/schemas/section-data.schema.ts
+++ b/src/modules/pages/schemas/section-data.schema.ts
@@ -106,6 +106,20 @@ const ALLOWED_HTML_OPTIONS: sanitizeHtml.IOptions = {
     td: ['colspan', 'rowspan'],
     '*': ['class', 'style'],
   },
+  // Restrict inline styles to a small, explicit allowlist of safe properties.
+  // This prevents arbitrary CSS from being injected while still allowing
+  // basic text formatting coming from the editor.
+  allowedStyles: {
+    '*': {
+      'text-align': [/^(?:left|right|center|justify)$/],
+      'font-weight': [/^(?:normal|bold|bolder|lighter|[1-9]00)$/],
+      'font-style': [/^(?:normal|italic)$/],
+      'text-decoration': [/^(?:none|underline|line-through|overline)$/],
+      // Basic color formats: hex, rgb[a], hsl[a], or named colors.
+      color: [/^(?:#[0-9a-fA-F]{3,8}|rgba?\([^)]*\)|hsla?\([^)]*\)|[a-zA-Z]+)$/],
+      'background-color': [/^(?:#[0-9a-fA-F]{3,8}|rgba?\([^)]*\)|hsla?\([^)]*\)|[a-zA-Z]+)$/],
+    },
+  },
   allowedSchemes: ['http', 'https', 'mailto', 'tel'],
   allowedSchemesByTag: {
     img: ['http', 'https'],

--- a/src/modules/pages/schemas/section-data.schema.ts
+++ b/src/modules/pages/schemas/section-data.schema.ts
@@ -1,3 +1,4 @@
+import sanitizeHtml from 'sanitize-html';
 import { z } from 'zod';
 import { SectionType } from '../../../generated/prisma/enums.js';
 
@@ -61,25 +62,69 @@ export const CtaDataSchema = z.object({
 });
 
 /**
- * Rejects strings that contain HTML/JS injection patterns.
- * Defense-in-depth: content is also expected to be sanitized on the frontend
- * before rendering. If rich-text HTML is needed here, replace this refinement
- * with a server-side sanitize-html call using a strict element/attribute allowlist.
+ * Strict HTML allowlist for TEXT sections.
+ * Only formatting/structure elements that render safely in the admin panel
+ * are permitted. No script, no event handlers, no javascript: URIs.
  */
-const UNSAFE_HTML_RE = /<script[\s>]/i;
-const UNSAFE_ATTR_RE = /\s+on[a-z]+\s*=/i;
-const JAVASCRIPT_PROTO_RE = /javascript\s*:/i;
+const ALLOWED_HTML_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'p',
+    'br',
+    'hr',
+    'ul',
+    'ol',
+    'li',
+    'strong',
+    'em',
+    'u',
+    's',
+    'code',
+    'pre',
+    'blockquote',
+    'a',
+    'img',
+    'table',
+    'thead',
+    'tbody',
+    'tr',
+    'th',
+    'td',
+    'span',
+    'div',
+    'mark',
+  ],
+  allowedAttributes: {
+    a: ['href', 'title', 'target', 'rel'],
+    img: ['src', 'alt', 'title', 'width', 'height'],
+    th: ['colspan', 'rowspan'],
+    td: ['colspan', 'rowspan'],
+    '*': ['class', 'style'],
+  },
+  allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+  allowedSchemesByTag: {
+    img: ['http', 'https'],
+  },
+  // Force safe link behaviour
+  transformTags: {
+    a: sanitizeHtml.simpleTransform('a', { rel: 'noopener noreferrer' }, true),
+  },
+};
 
 const safeHtmlString = () =>
   z
     .string()
     .min(1)
     .max(50_000)
-    .refine((v) => !UNSAFE_HTML_RE.test(v), { message: '<script> elements are not allowed' })
-    .refine((v) => !UNSAFE_ATTR_RE.test(v), {
-      message: 'Inline event handlers (on*=) are not allowed',
-    })
-    .refine((v) => !JAVASCRIPT_PROTO_RE.test(v), { message: 'javascript: URIs are not allowed' });
+    .transform((v) => sanitizeHtml(v, ALLOWED_HTML_OPTIONS))
+    .refine((v) => v.trim().length > 0, {
+      message: 'HTML content must not be empty after sanitization',
+    });
 
 export const TextDataSchema = z.object({
   content: safeHtmlString(),

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -126,6 +126,10 @@ export class PrismaService implements OnModuleInit, OnModuleDestroy {
     return this.prisma.newsArticle;
   }
 
+  get articleCard(): PrismaClientInstance['articleCard'] {
+    return this.prisma.articleCard;
+  }
+
   get company(): PrismaClientInstance['company'] {
     return this.prisma.company;
   }


### PR DESCRIPTION
- Introduced new Zod schemas for TEXT, QUOTE, PUBLICATION, IMAGE, and VIDEO card data.
- Implemented a validation function to ensure card data adheres to the defined schemas.
- Enhanced CreatePageDto and UpdatePageDto with trimming transformation for the name field.
- Updated PagesController to use ParseSlugPipe for slug parameters in relevant routes.
- Improved error handling in PagesService for page updates to handle not found scenarios.
- Added strict HTML sanitization for TEXT sections in section-data.schema.ts.
- Exposed articleCard in PrismaService for easier access to article card data.