### PR TITLE
fix: add SCP step to copy docker-compose.prod.yml to server before deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,17 @@ jobs:
             docker-compose.prod.yml
             deploy/
 
+      - name: Copy deploy configs to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
+          source: "docker-compose.prod.yml"
+          target: "/opt/icgroup"
+          overwrite: true
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.2.0
         with:


### PR DESCRIPTION
## Problem

The CI deploy job SSHes into the server and runs `docker compose` with whatever `docker-compose.prod.yml` is already at `/opt/icgroup/` — but **never copies the updated file from the repo to the server**. 

This means any changes to `docker-compose.prod.yml` in the repo (like adding `SWAGGER_USER` and `SWAGGER_PASSWORD` env var mappings) never reach the production server, causing the app to crash with:

```
Config validation error: "SWAGGER_USER" is required. "SWAGGER_PASSWORD" is required
```

## Fix

Added an `appleboy/scp-action` step in the deploy job that copies `docker-compose.prod.yml` from the checked-out repo to `/opt/icgroup/` on the server **before** running `docker compose up`.

### Deploy flow (before):
1. Checkout `docker-compose.prod.yml` (on runner — never used)
2. SSH → `docker compose up` (uses old file on server)

### Deploy flow (after):
1. Checkout `docker-compose.prod.yml` (on runner)
2. **SCP → copy `docker-compose.prod.yml` to server** ← NEW
3. SSH → `docker compose up` (uses freshly copied file)