### PR TITLE
fix: add SCP step to copy docker-compose.prod.yml to server before de…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,17 @@ jobs:
             docker-compose.prod.yml
             deploy/
 
+      - name: Copy deploy configs to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
+          source: "docker-compose.prod.yml,deploy"
+          target: "/opt/icgroup"
+          overwrite: true
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.2.0
         with:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,6 +49,8 @@ services:
       THROTTLE_LOGIN_TTL: ${THROTTLE_LOGIN_TTL:-60}
       THROTTLE_LOGIN_LIMIT: ${THROTTLE_LOGIN_LIMIT:-5}
       SWAGGER_ENABLED: ${SWAGGER_ENABLED:-false}
+      SWAGGER_USER: ${SWAGGER_USER:-}
+      SWAGGER_PASSWORD: ${SWAGGER_PASSWORD:-}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
…ploy (#34)

* fix(deploy): correct GHCR image name and add --env-file to deploy script

- Fix APP_IMAGE default: ghcr.io/icgroup/ -> ghcr.io/kiraprosto/ (matches github.repository)
- Add --env-file .env.production to all docker compose commands in CI deploy
- Fixes 'image not found' and blank env var warnings during deployment

* fix: pass SWAGGER_USER and SWAGGER_PASSWORD to app container in docker-compose.prod.yml

* fix: add SCP step to copy docker-compose.prod.yml to server before deploy

The CI deploy job was running docker compose on the server using whatever old docker-compose.prod.yml was already in /opt/icgroup — it never copied the updated file from the repo. This caused env var additions (like SWAGGER_USER and SWAGGER_PASSWORD) to never reach the server.

Added appleboy/scp-action step to transfer docker-compose.prod.yml from the checked-out repo to the server before running docker compose.

* fix: restore uptime-kuma-data volume name and add SWAGGER env vars\n\nThe previous commit accidentally renamed the Uptime Kuma volume from\nuptime-kuma-data to kuma-data, which would cause data loss on the server\n(new empty volume created, old data orphaned).\n\nThis commit:\n- Restores the original volume name uptime-kuma-data\n- Adds SWAGGER_USER and SWAGGER_PASSWORD env var passthrough to the app\n  service (needed for Swagger HTTP Basic Auth in production)"

* fix: include deploy/ directory in SCP step\n\nThe compose file mounts ./deploy/nginx/... volumes, so nginx configs\nmust also be copied to the server alongside docker-compose.prod.yml.\nWithout this, nginx config changes in the repo would never reach the\nserver, leaving configs stale."