### PR TITLE
fix: replace scp-action with native scp, secure GHCR_TOKEN passing (#38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,16 +198,23 @@ jobs:
             deploy/
 
       - name: Copy deploy configs to server
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
-          source: "docker-compose.prod.yml,deploy"
-          target: "/opt/icgroup"
-          overwrite: true
-          tar_exec: tar --no-same-owner
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          install -m 600 /dev/null deploy_key
+          printf '%s\n' "$DEPLOY_SSH_KEY" > deploy_key
+          PORT="${{ secrets.DEPLOY_SSH_PORT || 22 }}"
+          SSH_OPTS="-i deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+          scp -P "$PORT" $SSH_OPTS \
+            docker-compose.prod.yml \
+            "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/icgroup/"
+
+          scp -P "$PORT" $SSH_OPTS -r \
+            deploy \
+            "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/icgroup/"
+
+          rm -f deploy_key
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.2.0
@@ -217,6 +224,7 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
           script_stop: true
+          envs: GHCR_TOKEN,GHCR_USER
           script: |
             set -e
 
@@ -224,7 +232,7 @@ jobs:
             cd "$APP_DIR"
 
             echo "==> Logging in to GHCR..."
-            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
             echo "==> Pulling latest image..."
             docker compose -f docker-compose.prod.yml --env-file .env.production pull app
@@ -250,6 +258,9 @@ jobs:
             docker image prune -f
 
             echo "==> Deployment complete!"
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
 
       - name: Verify deployment
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
* fix(deploy): correct GHCR image name and add --env-file to deploy script

- Fix APP_IMAGE default: ghcr.io/icgroup/ -> ghcr.io/kiraprosto/ (matches github.repository)
- Add --env-file .env.production to all docker compose commands in CI deploy
- Fixes 'image not found' and blank env var warnings during deployment

* fix: pass SWAGGER_USER and SWAGGER_PASSWORD to app container in docker-compose.prod.yml

* fix: replace scp-action with native scp, secure GHCR_TOKEN passing\n\nThe appleboy/scp-action uses tar internally to transfer files. The\nremote tar extraction fails because tar_exec only accepts a binary\npath, not a command with flags (\"tar --no-same-owner\" treated as\nsingle executable name).\n\nChanges:\n1. Replace appleboy/scp-action with native scp in a run step.\n   SCP transfers files directly without tar — no permission issues.\n2. Pass GHCR_TOKEN via ssh-action envs parameter instead of\n   interpolating secrets directly into the script body."