### PR TITLE
fix: allow empty SWAGGER_USER/PASSWORD when Swagger is disabled (#41)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -67,3 +67,12 @@ THROTTLE_LOGIN_LIMIT=5
 
 # Enable when behind nginx / ALB / reverse proxy (required in production)
 TRUST_PROXY=true
+
+# ─────────────────────────────────────────────
+#  Swagger (API documentation)
+# ─────────────────────────────────────────────
+# Set to true to enable Swagger UI at /api/docs (protected by HTTP Basic Auth)
+SWAGGER_ENABLED=false
+# Required when SWAGGER_ENABLED=true in production/staging (min 4 / min 12 chars)
+# SWAGGER_USER=
+# SWAGGER_PASSWORD=

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -98,23 +98,25 @@ const nodeEnv = process.env['NODE_ENV'] ?? 'development';
         TRUST_PROXY: Joi.boolean().default(false),
         SWAGGER_ENABLED: Joi.boolean().default(false),
         // Swagger HTTP Basic Auth credentials — required in production/staging when Swagger is enabled.
+        // .allow('') is needed because docker-compose passes empty strings (not undefined)
+        // when the var is absent from .env.production.
         SWAGGER_USER: Joi.when('SWAGGER_ENABLED', {
           is: true,
           then: Joi.when('NODE_ENV', {
             is: Joi.valid('production', 'staging'),
             then: Joi.string().min(4).required(),
-            otherwise: Joi.string().optional(),
+            otherwise: Joi.string().allow('').optional(),
           }),
-          otherwise: Joi.string().optional(),
+          otherwise: Joi.string().allow('').optional(),
         }),
         SWAGGER_PASSWORD: Joi.when('SWAGGER_ENABLED', {
           is: true,
           then: Joi.when('NODE_ENV', {
             is: Joi.valid('production', 'staging'),
             then: Joi.string().min(12).required(),
-            otherwise: Joi.string().optional(),
+            otherwise: Joi.string().allow('').optional(),
           }),
-          otherwise: Joi.string().optional(),
+          otherwise: Joi.string().allow('').optional(),
         }),
         // How long (ms) to wait for graceful shutdown before forcing process.exit(1).
         SHUTDOWN_TIMEOUT_MS: Joi.number().integer().min(1000).default(10_000),
@@ -218,19 +220,19 @@ const nodeEnv = process.env['NODE_ENV'] ?? 'development';
     // ── Database (global — available to all feature modules) ───────
     PrismaModule,
 
-    // ── Health checks ──────────────────────────────────────
+    // ── Health checks ──────────────────────────────────
     HealthModule,
 
-    // ── Auth (JWT + refresh token) ─────────────────────────
+    // ── Auth (JWT + refresh token) ─────────────────────
     AuthModule,
 
     // ── RBAC (CASL PoliciesGuard — runs after JwtAuthGuard) ─
     CaslModule,
 
-    // ── User management (SUPER_ADMIN only) ────────────────
+    // ── User management (SUPER_ADMIN only) ──────────────
     UsersModule,
 
-    // ── Content management ─────────────────────────────
+    // ── Content management ─────────────────────────
     PagesModule,
     NewsModule,
     MediaModule,


### PR DESCRIPTION
* fix(deploy): correct GHCR image name and add --env-file to deploy script

- Fix APP_IMAGE default: ghcr.io/icgroup/ -> ghcr.io/kiraprosto/ (matches github.repository)
- Add --env-file .env.production to all docker compose commands in CI deploy
- Fixes 'image not found' and blank env var warnings during deployment

* fix: pass SWAGGER_USER and SWAGGER_PASSWORD to app container in docker-compose.prod.yml

* fix: allow empty SWAGGER_USER/PASSWORD when Swagger is disabled\n\nJoi.string().optional() allows undefined but rejects empty strings.\nDocker Compose sets SWAGGER_USER: ${SWAGGER_USER:-} which resolves\nto \"\" (empty string) when the var is absent from .env.production.\nThis crashes the app at startup even when Swagger is disabled.\n\nAdd .allow('') to the optional Joi branches so empty strings are\naccepted when Swagger is off or in non-production environments.\nThe production+enabled path still enforces min-length credentials.\n\nAlso adds Swagger vars to .env.production.example for discoverability."

* fix: correct Swagger route and mention staging in env example comments