### PR TITLE
ci: forward Swagger credentials from GitHub Actions to server on deploy

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -71,8 +71,12 @@ TRUST_PROXY=true
 # ─────────────────────────────────────────────
 #  Swagger (API documentation)
 # ─────────────────────────────────────────────
-# Set to true to enable Swagger UI at /api/docs (protected by HTTP Basic Auth)
+# Set to true to enable Swagger UI at /api/docs (protected by HTTP Basic Auth).
+# These values are managed automatically by the CI/CD pipeline:
+#   - SWAGGER_ENABLED: GitHub Actions variable (vars.SWAGGER_ENABLED)
+#   - SWAGGER_USER:    GitHub Actions variable (vars.SWAGGER_USER, min 4 chars)
+#   - SWAGGER_PASSWORD: GitHub Actions secret  (secrets.SWAGGER_PASSWORD, min 12 chars)
+# The deploy step writes them to this file when SWAGGER_ENABLED=true.
 SWAGGER_ENABLED=false
-# Required when SWAGGER_ENABLED=true in production/staging (min 4 / min 12 chars)
 # SWAGGER_USER=
 # SWAGGER_PASSWORD=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,12 +224,25 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
           script_stop: true
-          envs: GHCR_TOKEN,GHCR_USER
+          envs: GHCR_TOKEN,GHCR_USER,SWAGGER_ENABLED,SWAGGER_USER,SWAGGER_PASSWORD
           script: |
             set -e
 
             APP_DIR="/opt/icgroup"
             cd "$APP_DIR"
+
+            # ── Update Swagger settings in .env.production ──────────
+            # Remove stale Swagger lines (idempotent), then append current values.
+            # Only written when SWAGGER_ENABLED is explicitly "true".
+            if [ "$SWAGGER_ENABLED" = "true" ]; then
+              echo "==> Configuring Swagger credentials in .env.production..."
+              sed -i '/^SWAGGER_ENABLED=/d' .env.production
+              sed -i '/^SWAGGER_USER=/d' .env.production
+              sed -i '/^SWAGGER_PASSWORD=/d' .env.production
+              printf '%s\n' "SWAGGER_ENABLED=true" >> .env.production
+              printf '%s\n' "SWAGGER_USER=$SWAGGER_USER" >> .env.production
+              printf '%s\n' "SWAGGER_PASSWORD=$SWAGGER_PASSWORD" >> .env.production
+            fi
 
             echo "==> Logging in to GHCR..."
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
@@ -261,6 +274,9 @@ jobs:
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GHCR_USER: ${{ github.actor }}
+          SWAGGER_ENABLED: ${{ vars.SWAGGER_ENABLED }}
+          SWAGGER_USER: ${{ vars.SWAGGER_USER }}
+          SWAGGER_PASSWORD: ${{ secrets.SWAGGER_PASSWORD }}
 
       - name: Verify deployment
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
## What

The deploy step now forwards Swagger credentials from GitHub Actions to the server's `.env.production` file, enabling Swagger UI with HTTP Basic Auth in production.

## Changes

### `.github/workflows/ci.yml`
- Added `SWAGGER_ENABLED`, `SWAGGER_USER`, `SWAGGER_PASSWORD` to the `envs` list in the SSH deploy step
- Added env mappings: `vars.SWAGGER_ENABLED`, `vars.SWAGGER_USER` (GitHub Actions variables) and `secrets.SWAGGER_PASSWORD` (GitHub Actions secret)
- Before pulling the image, the script now checks if `SWAGGER_ENABLED=true` and idempotently writes the three Swagger vars into `.env.production` on the server (removes old lines via `sed`, then appends new values)

### `.env.production.example`
- Updated Swagger section comments to document that these values are managed by CI/CD

## Required GitHub Actions configuration

Before merging, ensure these are set in GitHub repo settings:

| Type | Name | Value |
|------|------|-------|
| **Variable** | `SWAGGER_ENABLED` | `true` |
| **Variable** | `SWAGGER_USER` | *(min 4 chars)* |
| **Secret** | `SWAGGER_PASSWORD` | *(min 12 chars)* |

## How it works

1. Deploy step receives vars/secrets as environment variables
2. If `SWAGGER_ENABLED=true`, the script removes any existing `SWAGGER_*` lines from `.env.production` and appends fresh values
3. `docker compose up` picks up the updated `.env.production`
4. App starts with Swagger enabled at `/api/docs`, protected by HTTP Basic Auth