### PR TITLE
Feature/swagger prod credentials (#45)

### DIFF
--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -1,0 +1,35 @@
+---
+applyTo: "**/*"
+---
+
+Git branching and merge rules — STRICTLY ENFORCED:
+
+Protected branches:
+- `main` and `dev` are protected branches.
+- NEVER push commits directly to `main` or `dev` — no exceptions.
+- ALL changes to `main` and `dev` MUST go through a Pull Request (Merge Request).
+- This applies to every kind of change: features, bug fixes, hotfixes, config changes, CI/CD fixes, typo fixes — everything.
+
+Workflow:
+- `dev` is the integration branch. `main` is the production branch.
+- Create a feature/fix branch from `dev` (e.g., `feature/add-auth`, `fix/swagger-env`).
+- Commit and push to the feature branch.
+- Open a Pull Request targeting `dev`.
+- The PR must be reviewed and approved before merging into `dev`.
+- To release to production: open a PR from `dev` to `main`. Never merge feature branches directly into `main`.
+- Never use `git push --force` on protected branches.
+
+What this means for the AI agent:
+- When asked to push changes, ALWAYS push to a feature branch — never to `main` or `dev`.
+- Feature branches MUST be created from `dev`, not from `main`.
+- Pull Requests MUST target `dev`. Never create a PR targeting `main` unless it is a `dev → main` release PR.
+- When using GitHub API tools (e.g., `mcp_io_github_git_push_files`, `mcp_io_github_git_create_or_update_file`), target the current working branch or create a new branch from `dev` — NEVER target `main` or `dev` directly.
+- After pushing to a feature branch, create a Pull Request targeting `dev` via `mcp_io_github_git_create_pull_request`.
+- If the user explicitly asks to push directly to `main` or `dev`, refuse and explain the rule. Suggest creating a PR instead.
+- If the user asks to create a PR to `main`, confirm whether they mean a release PR from `dev → main`. Feature/fix PRs always go to `dev`.
+
+Naming conventions:
+- Feature branches: `feature/<short-description>`
+- Bug fix branches: `fix/<short-description>`
+- Hotfix branches: `hotfix/<short-description>`
+- Chore/config branches: `chore/<short-description>`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,14 +234,18 @@ jobs:
             # ── Update Swagger settings in .env.production ──────────
             # Remove stale Swagger lines (idempotent), then append current values.
             # Only written when SWAGGER_ENABLED is explicitly "true".
+            # Dollar signs in values are doubled ($$) so docker-compose treats
+            # them as literal '$' instead of variable references.
             if [ "$SWAGGER_ENABLED" = "true" ]; then
               echo "==> Configuring Swagger credentials in .env.production..."
+              ESCAPED_USER=$(printf '%s' "$SWAGGER_USER" | sed 's/\$/\$\$/g')
+              ESCAPED_PASS=$(printf '%s' "$SWAGGER_PASSWORD" | sed 's/\$/\$\$/g')
               sed -i '/^SWAGGER_ENABLED=/d' .env.production
               sed -i '/^SWAGGER_USER=/d' .env.production
               sed -i '/^SWAGGER_PASSWORD=/d' .env.production
               printf '%s\n' "SWAGGER_ENABLED=true" >> .env.production
-              printf '%s\n' "SWAGGER_USER=$SWAGGER_USER" >> .env.production
-              printf '%s\n' "SWAGGER_PASSWORD=$SWAGGER_PASSWORD" >> .env.production
+              printf '%s\n' "SWAGGER_USER=$ESCAPED_USER" >> .env.production
+              printf '%s\n' "SWAGGER_PASSWORD=$ESCAPED_PASS" >> .env.production
             fi
 
             echo "==> Logging in to GHCR..."
@@ -255,7 +259,7 @@ jobs:
 
             echo "==> Waiting for health check..."
             for i in $(seq 1 30); do
-              if curl -sf http://localhost:3000/health > /dev/null 2>&1; then
+              if curl -skf https://localhost/health > /dev/null 2>&1; then
                 echo "==> Health check passed!"
                 break
               fi
@@ -290,5 +294,5 @@ jobs:
             docker compose -f /opt/icgroup/docker-compose.prod.yml --env-file /opt/icgroup/.env.production ps
             echo ""
             echo "==> API health:"
-            curl -sf http://localhost:3000/health | head -c 500
+            curl -sk https://localhost/health | head -c 500
             echo ""


### PR DESCRIPTION
* fix(deploy): correct GHCR image name and add --env-file to deploy script

- Fix APP_IMAGE default: ghcr.io/icgroup/ -> ghcr.io/kiraprosto/ (matches github.repository)
- Add --env-file .env.production to all docker compose commands in CI deploy
- Fixes 'image not found' and blank env var warnings during deployment

* fix: pass SWAGGER_USER and SWAGGER_PASSWORD to app container in docker-compose.prod.yml

* ci: forward Swagger credentials to server on deploy

The deploy step now writes SWAGGER_ENABLED, SWAGGER_USER, and SWAGGER_PASSWORD into .env.production on the VPS when SWAGGER_ENABLED=true. Values come from GitHub Actions vars/secrets.

* docs: add git workflow and branching rules to repository instructions

* fix(ci): escape dollar signs in passwords and fix health check using docker exec

* fix(ci): escape dollar signs in passwords and fix health check using docker exec

Two bugs found:
1. SWAGGER_PASSWORD containing $ caused Docker Compose to interpret $SUFFIX as a variable reference, silently truncating the password. Fix: escape $ as $$ when writing to .env.production.

2. Health check `curl localhost:3000` ran on the host, but the app container uses `expose` (not `ports`), so port 3000 is only reachable inside the Docker network. Fix: use `docker exec icgroup-api wget -qO-` to run the check inside the container (wget is available in Alpine, curl is not).

* fix(ci): health check via nginx (curl https://localhost) instead of docker exec

The node:24-alpine production image lacks wget/curl, so `docker exec` health checks fail. Instead, curl through nginx on port 443 (published to host) with -k to skip cert verification for localhost.

* fix(ci): replace wget with curl for health checks in CI workflow

---------