### PR TITLE
fix: reload nginx after deploy to resolve stale DNS for recreated app…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,10 @@ jobs:
             echo "==> Deploying..."
             docker compose -f docker-compose.prod.yml --env-file .env.production up -d --remove-orphans
 
+            echo "==> Reloading nginx to pick up new container IPs..."
+            docker compose -f docker-compose.prod.yml --env-file .env.production exec -T nginx nginx -s reload
+            sleep 2
+
             echo "==> Waiting for health check..."
             for i in $(seq 1 30); do
               if curl -skf https://localhost/health > /dev/null 2>&1; then

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -47,6 +47,9 @@ http {
     limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
     limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/m;
 
+    # ── DNS resolver (Docker embedded DNS) ───
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
     # ── Upstream ─────────────────────────────
     upstream app_backend {
         server app:3000;


### PR DESCRIPTION
… container (#47)

* fix(deploy): correct GHCR image name and add --env-file to deploy script

- Fix APP_IMAGE default: ghcr.io/icgroup/ -> ghcr.io/kiraprosto/ (matches github.repository)
- Add --env-file .env.production to all docker compose commands in CI deploy
- Fixes 'image not found' and blank env var warnings during deployment

* fix: pass SWAGGER_USER and SWAGGER_PASSWORD to app container in docker-compose.prod.yml

* ci: forward Swagger credentials to server on deploy

The deploy step now writes SWAGGER_ENABLED, SWAGGER_USER, and SWAGGER_PASSWORD into .env.production on the VPS when SWAGGER_ENABLED=true. Values come from GitHub Actions vars/secrets.

* docs: add git workflow and branching rules to repository instructions

* fix(ci): escape dollar signs in passwords and fix health check using docker exec

* fix(ci): escape dollar signs in passwords and fix health check using docker exec

Two bugs found:
1. SWAGGER_PASSWORD containing $ caused Docker Compose to interpret $SUFFIX as a variable reference, silently truncating the password. Fix: escape $ as $$ when writing to .env.production.

2. Health check `curl localhost:3000` ran on the host, but the app container uses `expose` (not `ports`), so port 3000 is only reachable inside the Docker network. Fix: use `docker exec icgroup-api wget -qO-` to run the check inside the container (wget is available in Alpine, curl is not).

* fix(ci): health check via nginx (curl https://localhost) instead of docker exec

The node:24-alpine production image lacks wget/curl, so `docker exec` health checks fail. Instead, curl through nginx on port 443 (published to host) with -k to skip cert verification for localhost.

* fix(ci): replace wget with curl for health checks in CI workflow

* fix: reload nginx after deploy to resolve stale DNS for recreated app container

When the app container is recreated during deployment, Docker assigns it a new IP. Nginx (which stays running) still has the old IP cached in its upstream resolution, causing 502 responses and health check failures.

- Add 'nginx -s reload' after 'docker compose up -d' in CI deploy script
- Add Docker embedded DNS resolver (127.0.0.11) to nginx.conf for automatic re-resolution with 10s TTL

---------