### PR TITLE
Feature/swagger prod credentials (#49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
 
             echo "==> Waiting for health check..."
             for i in $(seq 1 30); do
-              if curl -skf https://localhost/health > /dev/null 2>&1; then
+              if curl -sf http://localhost/health > /dev/null 2>&1; then
                 echo "==> Health check passed!"
                 break
               fi
@@ -298,5 +298,5 @@ jobs:
             docker compose -f /opt/icgroup/docker-compose.prod.yml --env-file /opt/icgroup/.env.production ps
             echo ""
             echo "==> API health:"
-            curl -sk https://localhost/health | head -c 500
+            curl -s http://localhost/health | head -c 500
             echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
 
             echo "==> Waiting for health check..."
             for i in $(seq 1 30); do
-              if curl -sf http://localhost/health > /dev/null 2>&1; then
+              if curl -sf --connect-timeout 5 --max-time 10 http://localhost/health > /dev/null 2>&1; then
                 echo "==> Health check passed!"
                 break
               fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,5 +298,12 @@ jobs:
             docker compose -f /opt/icgroup/docker-compose.prod.yml --env-file /opt/icgroup/.env.production ps
             echo ""
             echo "==> API health:"
-            curl -s http://localhost/health | head -c 500
+            HEALTH_RESPONSE="$(curl -fsS --max-time 10 http://localhost/health 2>&1)"
+            CURL_STATUS=$?
+            if [ "$CURL_STATUS" -ne 0 ]; then
+              echo "Health check failed (curl exit code: $CURL_STATUS)"
+              echo "$HEALTH_RESPONSE"
+              exit 1
+            fi
+            echo "$HEALTH_RESPONSE" | head -c 500
             echo ""


### PR DESCRIPTION
* fix(deploy): correct GHCR image name and add --env-file to deploy script

- Fix APP_IMAGE default: ghcr.io/icgroup/ -> ghcr.io/kiraprosto/ (matches github.repository)
- Add --env-file .env.production to all docker compose commands in CI deploy
- Fixes 'image not found' and blank env var warnings during deployment

* fix: pass SWAGGER_USER and SWAGGER_PASSWORD to app container in docker-compose.prod.yml

* fix: use HTTP for health check — nginx has no TLS certs yet

The active nginx config (default.conf) is HTTP-only on port 80. The HTTPS template (default.conf.template) is not active because Let's Encrypt certificates haven't been obtained yet.

curl -skf https://localhost/health always fails with connection refused since there is no listener on port 443.

Changed both the deploy health check and verify step to use http://localhost/health, matching the actual nginx config.